### PR TITLE
chore: update opencode-auth-provider to 0.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.27",
         "@opencode-ai/sdk": "latest",
-        "@tarquinen/opencode-auth-provider": "^0.1.3",
+        "@tarquinen/opencode-auth-provider": "^0.1.4",
         "ai": "^5.0.98",
         "gpt-tokenizer": "^3.4.0",
         "jsonc-parser": "^3.3.1",
@@ -1474,9 +1474,9 @@
       "license": "MIT"
     },
     "node_modules/@tarquinen/opencode-auth-provider": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@tarquinen/opencode-auth-provider/-/opencode-auth-provider-0.1.3.tgz",
-      "integrity": "sha512-ikxj/KOHXxruGghRRZFN1BfGI5bNaPq8pI3K5aRWgPu4Ik45YmuXpEmAlzGKsKGO5b903haUkwGGlHu8bx5UdA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@tarquinen/opencode-auth-provider/-/opencode-auth-provider-0.1.4.tgz",
+      "integrity": "sha512-dRQGfKqCw3/xBEBfPaAIH3nxYE+/3MYYT/bwbe4lCjdsBjJhXnS6+70sqjcpABMGdLyBwcn2A5kb3O0w+Bq9tw==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.936.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@ai-sdk/openai-compatible": "^1.0.27",
     "@opencode-ai/sdk": "latest",
-    "@tarquinen/opencode-auth-provider": "^0.1.3",
+    "@tarquinen/opencode-auth-provider": "^0.1.4",
     "ai": "^5.0.98",
     "gpt-tokenizer": "^3.4.0",
     "jsonc-parser": "^3.3.1",


### PR DESCRIPTION
## Summary
- Update `@tarquinen/opencode-auth-provider` dependency from `^0.1.3` to `^0.1.4`
- Version 0.1.4 fixes ESM module resolution by adding `.js` extensions to imports