### PR TITLE
refactor: simplify pruning tool name to 'prune'

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -88,7 +88,7 @@ const plugin: Plugin = (async (ctx) => {
         event: createEventHandler(ctx.client, janitor, logger, config, toolTracker),
         "chat.params": createChatParamsHandler(ctx.client, state, logger),
         tool: config.strategies.onTool.length > 0 ? {
-            "prune (DCP)": createPruningTool(janitor, config, toolTracker),
+            prune: createPruningTool(janitor, config, toolTracker),
         } : undefined,
     }
 }) satisfies Plugin

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -30,7 +30,7 @@ export interface ConfigResult {
 const defaultConfig: PluginConfig = {
     enabled: true,
     debug: false,
-    protectedTools: ['task', 'todowrite', 'todoread', 'prune (DCP)'],
+    protectedTools: ['task', 'todowrite', 'todoread', 'prune'],
     showModelErrorToasts: true,
     strictModelSelection: false,
     pruning_summary: 'detailed',
@@ -123,7 +123,7 @@ function createDefaultConfig(): void {
   "pruning_summary": "detailed",
   // How often to nudge the AI to prune (every N tool results, 0 = disabled)
   "nudge_freq": 10
-  // Additional tools to protect from pruning (merged with built-in: task, todowrite, todoread, prune (DCP))
+  // Additional tools to protect from pruning (merged with built-in: task, todowrite, todoread, prune)
   // "protectedTools": ["bash"]
 }
 `


### PR DESCRIPTION
## Summary
- Renames the pruning tool from `prune (DCP)` to simply `prune` for a cleaner, easier-to-type name
- Updates default protected tools list and config template comment to match