### PR TITLE
fix: restore full subagent prune rejection message

### DIFF
--- a/lib/pruning-tool.ts
+++ b/lib/pruning-tool.ts
@@ -45,7 +45,7 @@ export function createPruningTool(
             const sessionId = toolCtx.sessionID
 
             if (await isSubagentSession(client, sessionId)) {
-                return "Pruning is unavailable in subagent sessions. Do not call this tool again. Continue with your current task."
+                return "Pruning is unavailable in subagent sessions. Do not call this tool again. Continue with your current task - if you were in the middle of work, proceed with your next step. If you had just finished, provide your final summary/findings to return to the main agent."
             }
 
             if (!args.ids || args.ids.length === 0) {


### PR DESCRIPTION
## Summary
- Restore the helpful guidance message for subagents that was shortened in PR #61
- The full message tells subagents to continue with their current work or provide their final summary/findings to return to the main agent