### PR TITLE
feat: add showUpdateToasts config option to disable update notifications

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -65,7 +65,7 @@ const plugin: Plugin = (async (ctx) => {
 
     // Check for updates after a delay
     setTimeout(() => {
-        checkForUpdates(ctx.client, logger).catch(() => {})
+        checkForUpdates(ctx.client, logger, config.showUpdateToasts ?? true).catch(() => {})
     }, 5000)
 
     // Show migration toast if there were config migrations

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -13,6 +13,7 @@ export interface PluginConfig {
     protectedTools: string[]
     model?: string
     showModelErrorToasts?: boolean
+    showUpdateToasts?: boolean
     strictModelSelection?: boolean
     pruning_summary: "off" | "minimal" | "detailed"
     nudge_freq: number
@@ -32,6 +33,7 @@ const defaultConfig: PluginConfig = {
     debug: false,
     protectedTools: ['task', 'todowrite', 'todoread', 'prune', 'batch'],
     showModelErrorToasts: true,
+    showUpdateToasts: true,
     strictModelSelection: false,
     pruning_summary: 'detailed',
     nudge_freq: 10,
@@ -47,6 +49,7 @@ const VALID_CONFIG_KEYS = new Set([
     'protectedTools',
     'model',
     'showModelErrorToasts',
+    'showUpdateToasts',
     'strictModelSelection',
     'pruning_summary',
     'nudge_freq',
@@ -110,6 +113,8 @@ function createDefaultConfig(): void {
   // "model": "anthropic/claude-haiku-4-5",
   // Show toast notifications when model selection fails
   "showModelErrorToasts": true,
+  // Show toast notifications when a new version is available
+  "showUpdateToasts": true,
   // Only run AI analysis with session model or configured model (disables fallback models)
   "strictModelSelection": false,
   // AI analysis strategies (deduplication runs automatically on every request)
@@ -199,6 +204,7 @@ export function getConfig(ctx?: PluginInput): ConfigResult {
                     protectedTools: [...new Set([...config.protectedTools, ...(globalConfig.protectedTools ?? [])])],
                     model: globalConfig.model ?? config.model,
                     showModelErrorToasts: globalConfig.showModelErrorToasts ?? config.showModelErrorToasts,
+                    showUpdateToasts: globalConfig.showUpdateToasts ?? config.showUpdateToasts,
                     strictModelSelection: globalConfig.strictModelSelection ?? config.strictModelSelection,
                     strategies: mergeStrategies(config.strategies, globalConfig.strategies as any),
                     pruning_summary: globalConfig.pruning_summary ?? config.pruning_summary,
@@ -230,6 +236,7 @@ export function getConfig(ctx?: PluginInput): ConfigResult {
                     protectedTools: [...new Set([...config.protectedTools, ...(projectConfig.protectedTools ?? [])])],
                     model: projectConfig.model ?? config.model,
                     showModelErrorToasts: projectConfig.showModelErrorToasts ?? config.showModelErrorToasts,
+                    showUpdateToasts: projectConfig.showUpdateToasts ?? config.showUpdateToasts,
                     strictModelSelection: projectConfig.strictModelSelection ?? config.strictModelSelection,
                     strategies: mergeStrategies(config.strategies, projectConfig.strategies as any),
                     pruning_summary: projectConfig.pruning_summary ?? config.pruning_summary,

--- a/lib/version-checker.ts
+++ b/lib/version-checker.ts
@@ -50,7 +50,7 @@ export function isOutdated(local: string, remote: string): boolean {
     return false
 }
 
-export async function checkForUpdates(client: any, logger?: { info: (component: string, message: string, data?: any) => void }): Promise<void> {
+export async function checkForUpdates(client: any, logger?: { info: (component: string, message: string, data?: any) => void }, showToast: boolean = true): Promise<void> {
     try {
         const local = getLocalVersion()
         const npm = await getNpmVersion()
@@ -66,6 +66,10 @@ export async function checkForUpdates(client: any, logger?: { info: (component: 
         }
 
         logger?.info("version", "Update available", { local, npm })
+
+        if (!showToast) {
+            return
+        }
 
         await client.tui.showToast({
             body: {


### PR DESCRIPTION
## Summary
- Adds `showUpdateToasts` config option to disable "new version available" toast notifications
- Useful for users who frequently open/close opencode or prefer fixed versions

Closes #62