### PR TITLE
docs: add showUpdateToasts config option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add to your OpenCode config:
 ```jsonc
 // opencode.jsonc
 {
-  "plugin": ["@tarquinen/opencode-dcp@0.4.0"]
+  "plugin": ["@tarquinen/opencode-dcp@0.4.1"]
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tarquinen/opencode-dcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tarquinen/opencode-dcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.28",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@tarquinen/opencode-dcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "OpenCode plugin that optimizes token usage by pruning obsolete tool outputs from conversation context",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Document the `showUpdateToasts` configuration option in README that allows users to disable update notification toasts
- Bump version to 0.4.1

This documentation was missing from the v0.4.0 release which added the feature in #66.

**Full Changelog**: https://github.com/Tarquinen/opencode-dynamic-context-pruning/compare/v0.4.0...v0.4.1