### PR TITLE
Use primary_tools to restrict prune to main agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,14 @@ Add to your OpenCode config:
 ```jsonc
 // opencode.jsonc
 {
-  "plugin": ["@tarquinen/opencode-dcp@0.4.1"]
+  "plugin": ["@tarquinen/opencode-dcp@0.4.1"],
+  "experimental": {
+    "primary_tools": ["prune"]
+  }
 }
 ```
+
+The `experimental.primary_tools` setting ensures the `prune` tool is only available to the primary agent (not subagents).
 
 When a new version is available, DCP will show a toast notification. Update by changing the version number in your config.
 
@@ -83,20 +88,6 @@ DCP uses its own config file (`~/.config/opencode/dcp.jsonc` or `.opencode/dcp.j
 Settings are merged in order: **Defaults** → **Global** (`~/.config/opencode/dcp.jsonc`) → **Project** (`.opencode/dcp.jsonc`). Each level overrides the previous, so project settings take priority over global, which takes priority over defaults.
 
 Restart OpenCode after making config changes.
-
-## Subagents
-
-DCP automatically skips processing for subagent sessions (`general`, `explore`, etc.), but subagents can still invoke the `prune` tool. To prevent this, disable the tool in your OpenCode config. Any custom agents you've defined should also have prune disabled:
-
-```jsonc
-// opencode.jsonc
-{
-  "agent": {
-    "general": { "tools": { "prune": false } },
-    "explore": { "tools": { "prune": false } }
-  }
-}
-```
 
 ## License
 


### PR DESCRIPTION
## Summary
- Update setup instructions to use `experimental.primary_tools` config
- Remove manual subagent tool disabling (no longer needed)