### PR TITLE
refactor: use OpenCode session API as single source for tool parameters

### DIFF
--- a/lib/fetch-wrapper/formats/bedrock.ts
+++ b/lib/fetch-wrapper/formats/bedrock.ts
@@ -1,7 +1,5 @@
 import type { FormatDescriptor, ToolOutput, ToolTracker } from "../types"
 import type { PluginState } from "../../state"
-import type { Logger } from "../../logger"
-import { cacheToolParametersFromMessages } from "../../state/tool-cache"
 
 function isNudgeMessage(msg: any, nudgeText: string): boolean {
     if (typeof msg.content === 'string') {
@@ -86,28 +84,6 @@ export const bedrockFormat: FormatDescriptor = {
 
     getDataArray(body: any): any[] | undefined {
         return body.messages
-    },
-
-    cacheToolParameters(data: any[], state: PluginState, logger?: Logger): void {
-        // Extract toolUseId and tool name from assistant toolUse blocks
-        for (const m of data) {
-            if (m.role === 'assistant' && Array.isArray(m.content)) {
-                for (const block of m.content) {
-                    if (block.toolUse && block.toolUse.toolUseId) {
-                        const toolUseId = block.toolUse.toolUseId.toLowerCase()
-                        state.toolParameters.set(toolUseId, {
-                            tool: block.toolUse.name,
-                            parameters: block.toolUse.input
-                        })
-                        logger?.debug("bedrock", "Cached tool parameters", {
-                            toolUseId,
-                            toolName: block.toolUse.name
-                        })
-                    }
-                }
-            }
-        }
-        cacheToolParametersFromMessages(data, state, logger)
     },
 
     injectSynth(data: any[], instruction: string, nudgeText: string): boolean {

--- a/lib/fetch-wrapper/formats/gemini.ts
+++ b/lib/fetch-wrapper/formats/gemini.ts
@@ -1,6 +1,5 @@
 import type { FormatDescriptor, ToolOutput, ToolTracker } from "../types"
 import type { PluginState } from "../../state"
-import type { Logger } from "../../logger"
 
 function isNudgeContent(content: any, nudgeText: string): boolean {
     if (Array.isArray(content.parts) && content.parts.length === 1) {
@@ -70,10 +69,6 @@ export const geminiFormat: FormatDescriptor = {
 
     getDataArray(body: any): any[] | undefined {
         return body.contents
-    },
-
-    cacheToolParameters(_data: any[], _state: PluginState, _logger?: Logger): void {
-        // No-op: Gemini tool parameters are captured via message events in hooks.ts
     },
 
     injectSynth(data: any[], instruction: string, nudgeText: string): boolean {

--- a/lib/fetch-wrapper/formats/openai-chat.ts
+++ b/lib/fetch-wrapper/formats/openai-chat.ts
@@ -1,7 +1,5 @@
 import type { FormatDescriptor, ToolOutput, ToolTracker } from "../types"
 import type { PluginState } from "../../state"
-import type { Logger } from "../../logger"
-import { cacheToolParametersFromMessages } from "../../state/tool-cache"
 
 function isNudgeMessage(msg: any, nudgeText: string): boolean {
     if (typeof msg.content === 'string') {
@@ -77,10 +75,6 @@ export const openaiChatFormat: FormatDescriptor = {
 
     getDataArray(body: any): any[] | undefined {
         return body.messages
-    },
-
-    cacheToolParameters(data: any[], state: PluginState, logger?: Logger): void {
-        cacheToolParametersFromMessages(data, state, logger)
     },
 
     injectSynth(data: any[], instruction: string, nudgeText: string): boolean {

--- a/lib/fetch-wrapper/formats/openai-responses.ts
+++ b/lib/fetch-wrapper/formats/openai-responses.ts
@@ -1,7 +1,5 @@
 import type { FormatDescriptor, ToolOutput, ToolTracker } from "../types"
 import type { PluginState } from "../../state"
-import type { Logger } from "../../logger"
-import { cacheToolParametersFromInput } from "../../state/tool-cache"
 
 function isNudgeItem(item: any, nudgeText: string): boolean {
     if (typeof item.content === 'string') {
@@ -64,10 +62,6 @@ export const openaiResponsesFormat: FormatDescriptor = {
 
     getDataArray(body: any): any[] | undefined {
         return body.input
-    },
-
-    cacheToolParameters(data: any[], state: PluginState, logger?: Logger): void {
-        cacheToolParametersFromInput(data, state, logger)
     },
 
     injectSynth(data: any[], instruction: string, nudgeText: string): boolean {

--- a/lib/fetch-wrapper/types.ts
+++ b/lib/fetch-wrapper/types.ts
@@ -13,7 +13,6 @@ export interface FormatDescriptor {
     name: string
     detect(body: any): boolean
     getDataArray(body: any): any[] | undefined
-    cacheToolParameters(data: any[], state: PluginState, logger?: Logger): void
     injectSynth(data: any[], instruction: string, nudgeText: string): boolean
     trackNewToolResults(data: any[], tracker: ToolTracker, protectedTools: Set<string>): number
     injectPrunableList(data: any[], injection: string): boolean

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -121,13 +121,6 @@ export function createChatParamsHandler(
                                         toolCallsByName.set(toolName, [])
                                     }
                                     toolCallsByName.get(toolName)!.push(callId)
-
-                                    if (!state.toolParameters.has(callId)) {
-                                        state.toolParameters.set(callId, {
-                                            tool: part.tool,
-                                            parameters: part.input ?? {}
-                                        })
-                                    }
                                 }
                             }
                         }

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -15,9 +15,13 @@ export interface PluginState {
     lastSeenSessionId: string | null
 }
 
+export type ToolStatus = "pending" | "running" | "completed" | "error"
+
 export interface ToolParameterEntry {
     tool: string
     parameters: any
+    status?: ToolStatus
+    error?: string
 }
 
 export interface ModelInfo {


### PR DESCRIPTION
## Summary
- Replace format-specific tool parameter parsing with unified `syncToolParametersFromOpenCode()` that uses OpenCode's `session.messages()` API
- Remove ~80 lines of duplicated parsing code across 4 format adapters
- Add `status` and `error` fields to `ToolParameterEntry` for error detection