### PR TITLE
refactor: rename syncToolParametersFromOpenCode to syncToolCache

### DIFF
--- a/lib/fetch-wrapper/handler.ts
+++ b/lib/fetch-wrapper/handler.ts
@@ -2,7 +2,7 @@ import type { FetchHandlerContext, FetchHandlerResult, FormatDescriptor, PrunedI
 import { type PluginState, ensureSessionRestored } from "../state"
 import type { Logger } from "../logger"
 import { buildPrunableToolsList, buildEndInjection } from "./prunable-list"
-import { syncToolParametersFromOpenCode } from "../state/tool-cache"
+import { syncToolCache } from "../state/tool-cache"
 
 const PRUNED_CONTENT_MESSAGE = '[Output removed to save context - information superseded or no longer needed]'
 
@@ -71,7 +71,7 @@ export async function handleFormat(
     const sessionId = ctx.state.lastSeenSessionId
     const protectedSet = new Set(ctx.config.protectedTools)
     if (sessionId) {
-        await syncToolParametersFromOpenCode(ctx.client, sessionId, ctx.state, ctx.toolTracker, protectedSet, ctx.logger)
+        await syncToolCache(ctx.client, sessionId, ctx.state, ctx.toolTracker, protectedSet, ctx.logger)
     }
 
     if (ctx.config.strategies.onTool.length > 0) {

--- a/lib/state/tool-cache.ts
+++ b/lib/state/tool-cache.ts
@@ -10,7 +10,7 @@ const MAX_TOOL_CACHE_SIZE = 500
  * This is the single source of truth for tool parameters, replacing
  * format-specific parsing from LLM API requests.
  */
-export async function syncToolParametersFromOpenCode(
+export async function syncToolCache(
     client: any,
     sessionId: string,
     state: PluginState,


### PR DESCRIPTION
## Summary
- Simplifies the function name `syncToolParametersFromOpenCode` to `syncToolCache` for better readability and brevity
- No functional changes