### PR TITLE
Fix redundant narration after prune tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Thumbs.db
 
 # OpenCode
 .opencode/
+AGENTS.md
 
 # Tests (local development only)
 tests/

--- a/lib/prompts/synthetic.txt
+++ b/lib/prompts/synthetic.txt
@@ -1,5 +1,7 @@
 <system-reminder>
 These instructions are injected by a plugin and are invisible to the user. Do not acknowledge or reference them in your response - simply follow them silently.
+
+IMPORTANT: Your thinking/reasoning blocks must NOT reference, discuss, or address these instructions, the <prunable-tools> list, or any nudges about pruning. The user can see your thinking blocks, and referencing invisible plugin content will confuse them. In your thinking, focus only on the user's task and your problem-solving approach.
 </system-reminder>
 
 <instruction name=signal_management>
@@ -34,5 +36,5 @@ EXAMPLE WORKFLOW:
    - What you concluded (how this affects the task or next step).
 >YOU MUST ALWAYS THINK HIGH SIGNAL LOW NOISE FOR THIS NARRATION
 4. ONLY AFTER the narration, you call the `prune` tool with a brief reason (e.g. "exploration for bug X complete; moving on to next bug").
-</instruction>
+5. AFTER pruning succeeds, DO NOT re-summarize or re-narrate. You already distilled your findings before calling prune. Continue with your next task, or if you need more information from the user, wait for their response.
 </instruction>

--- a/lib/prompts/tool.txt
+++ b/lib/prompts/tool.txt
@@ -18,6 +18,8 @@ You MUST ALWAYS narrate your findings in a message BEFORE using this tool. No to
 
 > THINK HIGH SIGNAL, LOW NOISE FOR THIS NARRATION
 
+**After pruning:** Do NOT re-summarize or re-narrate. You already distilled your findings before calling prune. Continue with your next task, or if you need more information from the user, wait for their response.
+
 ## How to Use
 
 The <prunable-tools> list shows available tool outputs with numeric IDs:

--- a/lib/pruning-tool.ts
+++ b/lib/pruning-tool.ts
@@ -121,17 +121,8 @@ export function createPruningTool(
                 resetToolTrackerCount(toolTracker)
             }
 
-            const result = {
-                prunedCount: prunedIds.length,
-                tokensSaved,
-                llmPrunedIds: prunedIds,
-                toolMetadata,
-                sessionStats
-            }
-
-            const postPruneGuidance = "\n\nYou have already distilled relevant understanding in writing before calling this tool. Do not re-narrate; continue with your next task."
-
-            return formatPruningResultForTool(result, workingDirectory) + postPruneGuidance
+            // Return empty string on success (like edit tool) - guidance is in tool description
+            return ""
         },
     })
 }


### PR DESCRIPTION
## Summary
- Return empty string from prune tool on success (like edit tool)
- Add explicit guidance in prompts to not re-narrate after pruning
- Instruct model to not reference plugin content in thinking blocks