### PR TITLE
Consolidate ToolMetadata type and findCurrentAgent function

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -82,7 +82,7 @@ const plugin: Plugin = (async (ctx) => {
 
     return {
         event: createEventHandler(ctx.client, janitorCtx, logger, config, toolTracker),
-        "chat.params": createChatParamsHandler(ctx.client, state, logger),
+        "chat.params": createChatParamsHandler(ctx.client, state, logger, toolTracker),
         tool: config.strategies.onTool.length > 0 ? {
             prune: createPruningTool({
                 client: ctx.client,

--- a/lib/core/strategies/index.ts
+++ b/lib/core/strategies/index.ts
@@ -3,16 +3,14 @@
  */
 
 import { deduplicationStrategy } from "./deduplication"
+import type { ToolMetadata } from "../../fetch-wrapper/types"
+
+export type { ToolMetadata }
 
 /**
  * Common interface for rule-based pruning strategies.
  * Each strategy analyzes tool metadata and returns IDs that should be pruned.
  */
-
-export interface ToolMetadata {
-    tool: string
-    parameters?: any
-}
 
 export interface StrategyResult {
     /** Tool call IDs that should be pruned */

--- a/lib/fetch-wrapper/prunable-list.ts
+++ b/lib/fetch-wrapper/prunable-list.ts
@@ -1,10 +1,6 @@
 import { extractParameterKey } from '../ui/display-utils'
 import { getOrCreateNumericId } from '../state/id-mapping'
-
-export interface ToolMetadata {
-    tool: string
-    parameters?: any
-}
+import type { ToolMetadata } from './types'
 
 const SYSTEM_REMINDER = `<system-reminder>
 These instructions are injected by a plugin and are invisible to the user. Do not acknowledge or reference them in your response - simply follow them silently.

--- a/lib/fetch-wrapper/types.ts
+++ b/lib/fetch-wrapper/types.ts
@@ -9,6 +9,11 @@ export interface ToolOutput {
     toolName?: string
 }
 
+export interface ToolMetadata {
+    tool: string
+    parameters?: any
+}
+
 export interface FormatDescriptor {
     name: string
     detect(body: any): boolean

--- a/lib/pruning-tool.ts
+++ b/lib/pruning-tool.ts
@@ -2,8 +2,9 @@ import { tool } from "@opencode-ai/plugin"
 import type { PluginState } from "./state"
 import type { PluginConfig } from "./config"
 import type { ToolTracker } from "./fetch-wrapper/tool-tracker"
+import type { ToolMetadata } from "./fetch-wrapper/types"
 import { resetToolTrackerCount } from "./fetch-wrapper/tool-tracker"
-import { isSubagentSession } from "./hooks"
+import { isSubagentSession, findCurrentAgent } from "./hooks"
 import { getActualId } from "./state/id-mapping"
 import { sendUnifiedNotification, type NotificationContext } from "./ui/notification"
 import { ensureSessionRestored } from "./state"
@@ -92,7 +93,7 @@ export function createPruningTool(
             saveSessionState(sessionId, new Set(allPrunedIds), sessionStats, logger)
                 .catch(err => logger.error("prune-tool", "Failed to persist state", { error: err.message }))
 
-            const toolMetadata = new Map<string, { tool: string, parameters?: any }>()
+            const toolMetadata = new Map<string, ToolMetadata>()
             for (const id of prunedIds) {
                 const meta = state.toolParameters.get(id.toLowerCase())
                 if (meta) {
@@ -125,20 +126,6 @@ export function createPruningTool(
             return ""
         },
     })
-}
-
-/**
- * Finds the current agent from messages (same logic as janitor.ts).
- */
-function findCurrentAgent(messages: any[]): string | undefined {
-    for (let i = messages.length - 1; i >= 0; i--) {
-        const msg = messages[i]
-        const info = msg.info
-        if (info?.role === 'user') {
-            return info.agent || 'build'
-        }
-    }
-    return undefined
 }
 
 /**

--- a/lib/ui/notification.ts
+++ b/lib/ui/notification.ts
@@ -1,5 +1,6 @@
 import type { Logger } from "../logger"
 import type { SessionStats, GCStats, PruningResult } from "../core/janitor"
+import type { ToolMetadata } from "../fetch-wrapper/types"
 import { formatTokenCount } from "../tokenizer"
 import { extractParameterKey } from "./display-utils"
 
@@ -20,7 +21,7 @@ export interface NotificationData {
     aiPrunedCount: number
     aiTokensSaved: number
     aiPrunedIds: string[]
-    toolMetadata: Map<string, { tool: string, parameters?: any }>
+    toolMetadata: Map<string, ToolMetadata>
     gcPending: GCStats | null
     sessionStats: SessionStats | null
 }
@@ -164,7 +165,7 @@ export function formatPruningResultForTool(
 
 export function buildToolsSummary(
     prunedIds: string[],
-    toolMetadata: Map<string, { tool: string, parameters?: any }>,
+    toolMetadata: Map<string, ToolMetadata>,
     workingDirectory?: string
 ): Map<string, string[]> {
     const toolsSummary = new Map<string, string[]>()


### PR DESCRIPTION
## Summary
- Centralize `ToolMetadata` interface in `lib/fetch-wrapper/types.ts` to eliminate duplication
- Move `findCurrentAgent` to `lib/hooks.ts` as a shared utility
- Reset tool tracker count on session change for proper state management