### PR TITLE
Fix Gemini tool name resolution and session restore

### DIFF
--- a/lib/fetch-wrapper/formats/gemini.ts
+++ b/lib/fetch-wrapper/formats/gemini.ts
@@ -87,9 +87,10 @@ export const geminiFormat: FormatDescriptor = {
                         const toolCallId = positionMapping.get(positionKey)
 
                         if (toolCallId) {
+                            const metadata = state.toolParameters.get(toolCallId.toLowerCase())
                             outputs.push({
                                 id: toolCallId.toLowerCase(),
-                                toolName: funcName
+                                toolName: metadata?.tool
                             })
                         }
                     }

--- a/lib/fetch-wrapper/handler.ts
+++ b/lib/fetch-wrapper/handler.ts
@@ -71,6 +71,7 @@ export async function handleFormat(
     const sessionId = ctx.state.lastSeenSessionId
     const protectedSet = new Set(ctx.config.protectedTools)
     if (sessionId) {
+        await ensureSessionRestored(ctx.state, sessionId, ctx.logger)
         await syncToolCache(ctx.client, sessionId, ctx.state, ctx.toolTracker, protectedSet, ctx.logger)
     }
 


### PR DESCRIPTION
## Summary
- Ensure session state is restored before syncing tool cache
- Use tool metadata for Gemini tool name instead of raw function name