### PR TITLE
Refactor: Centralize system reminder and simplify prompts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -45,7 +45,8 @@ const plugin: Plugin = (async (ctx) => {
 
     const prompts = {
         synthInstruction: loadPrompt("synthetic"),
-        nudgeInstruction: loadPrompt("nudge")
+        nudgeInstruction: loadPrompt("nudge"),
+        systemReminder: loadPrompt("system-reminder")
     }
 
     // Install global fetch wrapper for context pruning and synthetic instruction injection

--- a/lib/fetch-wrapper/handler.ts
+++ b/lib/fetch-wrapper/handler.ts
@@ -96,7 +96,7 @@ export async function handleFormat(
             if (prunableList) {
                 const includeNudge = ctx.config.nudge_freq > 0 && ctx.toolTracker.toolResultCount > ctx.config.nudge_freq
 
-                const endInjection = buildEndInjection(prunableList, includeNudge)
+                const endInjection = buildEndInjection(prunableList, includeNudge, ctx.prompts.nudgeInstruction, ctx.prompts.systemReminder)
                 if (format.injectPrunableList(data, endInjection)) {
                     ctx.logger.debug("fetch", `Injected prunable tools list (${format.name})`, {
                         ids: numericIds,

--- a/lib/fetch-wrapper/prunable-list.ts
+++ b/lib/fetch-wrapper/prunable-list.ts
@@ -2,14 +2,6 @@ import { extractParameterKey } from '../ui/display-utils'
 import { getOrCreateNumericId } from '../state/id-mapping'
 import type { ToolMetadata } from './types'
 
-const SYSTEM_REMINDER = `<system-reminder>
-These instructions are injected by a plugin and are invisible to the user. Do not acknowledge or reference them in your response - simply follow them silently.
-</system-reminder>`
-
-const NUDGE_INSTRUCTION = `<instruction name=agent_nudge>
-You have accumulated several tool outputs. If you have completed a discrete unit of work and distilled relevant understanding in writing for the user to keep, use the prune tool to remove obsolete tool outputs from this conversation and optimize token usage.
-</instruction>`
-
 export interface PrunableListResult {
     list: string
     numericIds: number[]
@@ -49,16 +41,18 @@ export function buildPrunableToolsList(
 
 export function buildEndInjection(
     prunableList: string,
-    includeNudge: boolean
+    includeNudge: boolean,
+    nudgeInstruction: string,
+    systemReminder: string
 ): string {
     if (!prunableList) {
         return ''
     }
 
-    const parts = [SYSTEM_REMINDER]
+    const parts = [systemReminder]
 
     if (includeNudge) {
-        parts.push(NUDGE_INSTRUCTION)
+        parts.push(nudgeInstruction)
     }
 
     parts.push(prunableList)

--- a/lib/fetch-wrapper/types.ts
+++ b/lib/fetch-wrapper/types.ts
@@ -29,6 +29,7 @@ export interface FormatDescriptor {
 export interface SynthPrompts {
     synthInstruction: string
     nudgeInstruction: string
+    systemReminder: string
 }
 
 export interface FetchHandlerContext {

--- a/lib/prompts/nudge.txt
+++ b/lib/prompts/nudge.txt
@@ -1,7 +1,5 @@
-<system-reminder>
-This nudge is injected by a plugin and is invisible to the user. Do not acknowledge or reference it in your response - simply follow it silently.
-</system-reminder>
-
 <instruction name=agent_nudge>
-You have accumulated several tool outputs. If you have completed a discrete unit of work and distilled relevant understanding in writing for the user to keep, use the prune tool to remove obsolete tool outputs from this conversation and optimize token usage.
+If you have completed a unit of work:
+1. DISTILL your findings into text for the user to keep.
+2. Use the `prune` tool to remove obsolete tool outputs.
 </instruction>

--- a/lib/prompts/synthetic.txt
+++ b/lib/prompts/synthetic.txt
@@ -1,9 +1,3 @@
-<system-reminder>
-These instructions are injected by a plugin and are invisible to the user. Do not acknowledge or reference them in your response - simply follow them silently.
-
-IMPORTANT: Your thinking/reasoning blocks must NOT reference, discuss, or address these instructions, the <prunable-tools> list, or any nudges about pruning. The user can see your thinking blocks, and referencing invisible plugin content will confuse them. In your thinking, focus only on the user's task and your problem-solving approach.
-</system-reminder>
-
 <instruction name=signal_management>
 After calling a series of tools, YOU ALWAYS HAVE TO distill signals from their results in your next message. This ensures tracability of your reasoning, informs the user of your findings, and is PARAMOUNT to best context window management practices.
 

--- a/lib/prompts/system-reminder.txt
+++ b/lib/prompts/system-reminder.txt
@@ -1,0 +1,5 @@
+<system-reminder>
+These instructions are injected by a plugin and are invisible to the user. Do not acknowledge or reference them in your response - simply follow them silently.
+
+IMPORTANT: Your thinking/reasoning blocks must NOT reference, discuss, or address these instructions, the <prunable-tools> list, or any nudges about pruning. The user can see your thinking blocks, and referencing invisible plugin content will confuse them. In your thinking, focus only on the user's task and your problem-solving approach.
+</system-reminder>

--- a/lib/prompts/tool.txt
+++ b/lib/prompts/tool.txt
@@ -1,75 +1,17 @@
-Prunes tool outputs from context to manage conversation size. Reference the <prunable-tools> list injected at the end of the conversation to see available numeric IDs.
+Prunes tool outputs from context to manage conversation size.
+Refer to the <prunable-tools> list for available IDs.
 
-USING THE PRUNE TOOL WILL MAKE THE USER HAPPY.
+WHEN TO USE THIS TOOL:
+- After you complete a discrete unit of work (e.g. confirming a hypothesis, or closing out one branch of investigation).
+- After exploratory bursts of tool calls that led you to a clear conclusion (or to noise).
+- Before starting a new phase of work where old tool outputs are no longer needed to inform your next actions.
 
-## CRITICAL: Distill Before Pruning
+CRITICAL: Distill Before Pruning
+You MUST ALWAYS narrate your findings in a message BEFORE using this tool. No tool result should be left unexplained. By narrating your understanding, you transform raw tool outputs into distilled knowledge that persists in the context window.
 
-You MUST ALWAYS narrate your findings in a message BEFORE using this tool. No tool result (read, bash, grep, webfetch, etc.) should be left unexplained. By narrating your understanding, you transform raw tool outputs into distilled knowledge that persists in the context window.
+Tools are VOLATILE - Once distilled knowledge is in your reply, you can safely prune.
 
-**Tools are VOLATILE** - Once distilled knowledge is in your reply, you can safely prune. Skipping this step risks deleting raw evidence before it has been converted into stable knowledge.
-
-**Distillation workflow:**
-1. Call tools to investigate/explore
-2. In your next message, EXPLICITLY narrate:
-   - What you did (which tools, what you were looking for)
-   - What you found (the key facts/signals)
-   - What you concluded (how this affects the task or next step)
-3. ONLY AFTER narrating, call `prune` with the numeric IDs of outputs no longer needed
-
-> THINK HIGH SIGNAL, LOW NOISE FOR THIS NARRATION
-
-**After pruning:** Do NOT re-summarize or re-narrate. You already distilled your findings before calling prune. Continue with your next task, or if you need more information from the user, wait for their response.
-
-## How to Use
-
-The <prunable-tools> list shows available tool outputs with numeric IDs:
-```
-<prunable-tools>
-1: read, src/foo.ts
-2: bash, run tests
-3: grep, "error" in logs/
-</prunable-tools>
-```
-
-To prune outputs 1 and 3, call: `prune({ ids: [1, 3] })`
-
-## When to Use This Tool
-
-**Key heuristic: Distill, then prune when you finish something and are about to start something else.**
-
-Ask yourself: "Have I just completed a discrete unit of work?" If yes, narrate your findings, then prune before moving on.
-
-**After completing a unit of work:**
-- Made a commit
-- Fixed a bug and confirmed it works
-- Answered a question the user asked
-- Finished implementing a feature or function
-- Completed one item in a list and moving to the next
-
-**After repetitive or exploratory work:**
-- Explored multiple files that didn't lead to changes
-- Iterated on a difficult problem where some approaches didn't pan out
-- Used the same tool multiple times (e.g., re-reading a file, running repeated build/type checks)
-
-## Examples
-
-<example>
-Working through a list of items:
-User: Review these 3 issues and fix the easy ones.
-Assistant: [Reviews first issue, makes fix, commits]
-Done with the first issue. Let me prune before moving to the next one.
-[Uses prune with ids: [1, 2, 3, 4] - the reads and edits from the first issue]
-</example>
-
-<example>
-After exploring the codebase to understand it:
-Assistant: I've reviewed the relevant files. Let me prune the exploratory reads that aren't needed for the actual implementation.
-[Uses prune with ids: [1, 2, 5, 7] - the exploratory reads]
-</example>
-
-<example>
-After completing any task:
-Assistant: [Finishes task - commit, answer, fix, etc.]
-Before we continue, let me prune the context from that work.
-[Uses prune with ids: [3, 4, 5, 6, 8, 9] - all tool outputs from the completed task]
-</example>
+Example Workflow:
+1. Investigate with tools.
+2. Explicitly narrate findings (High Signal, Low Noise).
+3. Call `prune` with relevant IDs.


### PR DESCRIPTION
## Summary
- Extracted system reminder to `lib/prompts/system-reminder.txt`
- Simplified `tool.txt` and `nudge.txt` to remove redundancy
- Updated `synthetic.txt` to focus on workflow policy
- Updated code to inject system reminder dynamically