### PR TITLE
Update default config to protect edit/write tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ DCP uses its own config file (`~/.config/opencode/dcp.jsonc` or `.opencode/dcp.j
 | `strictModelSelection` | `false` | Only run AI analysis with session or configured model (disables fallback models) |
 | `pruning_summary` | `"detailed"` | `"off"`, `"minimal"`, or `"detailed"` |
 | `nudge_freq` | `10` | How often to remind AI to prune (lower = more frequent) |
-| `protectedTools` | `["task", "todowrite", "todoread", "prune"]` | Tools that are never pruned |
+| `protectedTools` | `["task", "todowrite", "todoread", "prune", "batch", "edit", "write"]` | Tools that are never pruned |
 | `strategies.onIdle` | `["ai-analysis"]` | Strategies for automatic pruning |
 | `strategies.onTool` | `["ai-analysis"]` | Strategies when AI calls `prune` |
 
@@ -79,7 +79,7 @@ DCP uses its own config file (`~/.config/opencode/dcp.jsonc` or `.opencode/dcp.j
     "onIdle": ["ai-analysis"],
     "onTool": ["ai-analysis"]
   },
-  "protectedTools": ["task", "todowrite", "todoread", "prune"]
+  "protectedTools": ["task", "todowrite", "todoread", "prune", "batch", "edit", "write"]
 }
 ```
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -31,12 +31,12 @@ export interface ConfigResult {
 const defaultConfig: PluginConfig = {
     enabled: true,
     debug: false,
-    protectedTools: ['task', 'todowrite', 'todoread', 'prune', 'batch'],
+    protectedTools: ['task', 'todowrite', 'todoread', 'prune', 'batch', 'edit', 'write'],
     showModelErrorToasts: true,
     showUpdateToasts: true,
     strictModelSelection: false,
     pruning_summary: 'detailed',
-    nudge_freq: 0,
+    nudge_freq: 10,
     strategies: {
         onIdle: ['ai-analysis'],
         onTool: ['ai-analysis']


### PR DESCRIPTION
## Summary
- Add `edit` and `write` to default protected tools list
- Set default `nudge_freq` to 10 (was 0)
- Update README to reflect new defaults