### PR TITLE
Remove redundant tool list from config comment

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -128,7 +128,7 @@ function createDefaultConfig(): void {
   "pruning_summary": "detailed",
   // How often to nudge the AI to prune (every N tool results, 0 = disabled)
   "nudge_freq": 10
-  // Additional tools to protect from pruning (merged with built-in: task, todowrite, todoread, prune, batch)
+  // Additional tools to protect from pruning
   // "protectedTools": ["bash"]
 }
 `


### PR DESCRIPTION
## Summary
- Remove hardcoded tool list from protectedTools config comment
- The built-in protected tools are managed internally and shouldn't be documented in user config