### PR TITLE
Release v0.4.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add to your OpenCode config:
 ```jsonc
 // opencode.jsonc
 {
-  "plugin": ["@tarquinen/opencode-dcp@0.4.2"],
+  "plugin": ["@tarquinen/opencode-dcp@0.4.12"],
   "experimental": {
     "primary_tools": ["prune"]
   }
@@ -24,7 +24,7 @@ The `experimental.primary_tools` setting ensures the `prune` tool is only availa
 
 When a new version is available, DCP will show a toast notification. Update by changing the version number in your config.
 
-> **Note:** Using `@latest` (e.g. `@tarquinen/opencode-dcp@latest`) does not reliably force the latest update in Opencode. Please use specific version numbers (e.g. `@0.4.2`).
+> **Note:** Using `@latest` (e.g. `@tarquinen/opencode-dcp@latest`) does not reliably force the latest update in Opencode. Please use specific version numbers (e.g. `@0.4.12`).
 
 Restart OpenCode. The plugin will automatically start optimizing your sessions.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tarquinen/opencode-dcp",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tarquinen/opencode-dcp",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.28",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@tarquinen/opencode-dcp",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "type": "module",
   "description": "OpenCode plugin that optimizes token usage by pruning obsolete tool outputs from conversation context",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Release v0.4.12 - Versions 0.4.3-0.4.11 were unlisted.

### Changes since v0.4.11:
- **Add write and edit to protected tools** - Prevents accidental pruning of file modification outputs
- **Fix nudge injection** - Insert nudge before tool_use blocks for proper Anthropic API compatibility  
- **Remove autoUpdate feature** - Simplify version checking (manual updates only now)
- **Cleanup** - Remove redundant tool list from config comment
- **Docs** - Update demo image in README

### Version References Updated:
- Updated README.md install example and note to reference `@0.4.12`