### PR TITLE
Release v0.4.13 - Use user messages for prunable list

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add to your OpenCode config:
 ```jsonc
 // opencode.jsonc
 {
-  "plugin": ["@tarquinen/opencode-dcp@0.4.12"],
+  "plugin": ["@tarquinen/opencode-dcp@0.4.13"],
   "experimental": {
     "primary_tools": ["prune"]
   }
@@ -24,7 +24,7 @@ The `experimental.primary_tools` setting ensures the `prune` tool is only availa
 
 When a new version is available, DCP will show a toast notification. Update by changing the version number in your config.
 
-> **Note:** Using `@latest` (e.g. `@tarquinen/opencode-dcp@latest`) does not reliably force the latest update in Opencode. Please use specific version numbers (e.g. `@0.4.12`).
+> **Note:** Using `@latest` (e.g. `@tarquinen/opencode-dcp@latest`) does not reliably force the latest update in Opencode. Please use specific version numbers (e.g. `@0.4.13`).
 
 Restart OpenCode. The plugin will automatically start optimizing your sessions.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tarquinen/opencode-dcp",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tarquinen/opencode-dcp",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.28",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@tarquinen/opencode-dcp",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "type": "module",
   "description": "OpenCode plugin that optimizes token usage by pruning obsolete tool outputs from conversation context",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Reverts prunable tool list injection from assistant messages back to user messages for better compatibility with various model providers
- Adds improved message guidance for the prunable tools list

## Changes included

- `a0d3277` - Change prunable list injection from assistant to user message
- `0dde97e` - prompt: prunable tools message guidance