### PR TITLE
v0.4.15 - Auto-configure prune as primary tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tarquinen/opencode-dcp",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tarquinen/opencode-dcp",
-      "version": "0.4.14",
+      "version": "0.4.15",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.28",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@tarquinen/opencode-dcp",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "type": "module",
   "description": "OpenCode plugin that optimizes token usage by pruning obsolete tool outputs from conversation context",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Automatically register `prune` tool as a primary tool via config hook, eliminating manual `experimental.primary_tools` configuration
- Simplify setup by removing the now-unnecessary config from README
- Clean up redundant subagent check (now handled by OpenCode's primary_tools mechanism)

## Changes

- **index.ts**: Add config hook to inject `prune` into `experimental.primary_tools`
- **lib/pruning-tool.ts**: Remove subagent session check (no longer needed)
- **README.md**: Remove manual `primary_tools` config from installation instructions
- **package.json**: Update `@opencode-ai/plugin` devDependency