### PR TITLE
Fix tool result counting on session restart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tarquinen/opencode-dcp",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tarquinen/opencode-dcp",
-      "version": "0.4.15",
+      "version": "0.4.16",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.28",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@tarquinen/opencode-dcp",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "type": "module",
   "description": "OpenCode plugin that optimizes token usage by pruning obsolete tool outputs from conversation context",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Fix tool result counting to not re-count already-pruned tools when a session is restarted
- Properly clear tool tracker state (seenToolResultIds, skipNextIdle) when switching sessions

## Details

When restarting a session, the tool cache sync was counting all tool results again, including those that had already been pruned. This could cause the pruning threshold to be reached prematurely.

This fix:
1. Adds a `clearToolTracker` function that resets all tracker state when switching sessions
2. Modifies `syncToolCache` to skip already-pruned tools when counting toward the nudge threshold
3. Removes unused `PruneReason` import from janitor.ts

**Version bump:** 0.4.15 → 0.4.16