### PR TITLE
refactor: remove unused reason parameter from buildAnalysisPrompt

### DIFF
--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -122,18 +122,12 @@ export function buildAnalysisPrompt(
     unprunedToolCallIds: string[],
     messages: any[],
     alreadyPrunedIds?: string[],
-    protectedToolCallIds?: string[],
-    reason?: string
+    protectedToolCallIds?: string[]
 ): string {
     const minimizedMessages = minimizeMessages(messages, alreadyPrunedIds, protectedToolCallIds)
     const messagesJson = JSON.stringify(minimizedMessages, null, 2).replace(/\\n/g, '\n')
 
-    const reasonContext = reason
-        ? `\nContext: The AI has requested pruning with the following reason: "${reason}"\nUse this context to inform your decisions about what is most relevant to keep.`
-        : ''
-
     return loadPrompt("pruning", {
-        reason_context: reasonContext,
         available_tool_call_ids: unprunedToolCallIds.join(", "),
         session_history: messagesJson
     })

--- a/lib/prompts/pruning.txt
+++ b/lib/prompts/pruning.txt
@@ -1,5 +1,5 @@
 You are a conversation analyzer that identifies obsolete tool outputs in a coding session.
-{{reason_context}}
+
 Your task: Analyze the session history and identify tool call IDs whose outputs are NO LONGER RELEVANT to the current conversation context.
 
 Guidelines for identifying obsolete tool calls:


### PR DESCRIPTION
## Summary
- Remove dead code: the `reason` parameter in `buildAnalysisPrompt` was never passed by any caller