### PR TITLE
v1.0.0-beta.2 - Fix nudge counter reset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tarquinen/opencode-dcp",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tarquinen/opencode-dcp",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.28",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@tarquinen/opencode-dcp",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "type": "module",
   "description": "OpenCode plugin that optimizes token usage by pruning obsolete tool outputs from conversation context",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Fix nudge counter to properly reset after prune tool is used
- Increase MAX_TOOL_CACHE_SIZE from 500 to 1000 for better session handling
- Refactor sync logic to correctly track nudge counter across session restarts

## Changes

This release addresses an issue where the nudge counter wasn't being reset properly after the prune tool was used, which could lead to premature or delayed pruning nudges.

**Full Changelog**: https://github.com/Opencode-DCP/opencode-dynamic-context-pruning/compare/v1.0.0-beta.1...v1.0.0-beta.2