### PR TITLE
 Support DCP config in $OPENCODE_CONFIG_DIR  (updated from PR #112 to latest dev branch rebase) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ LLM providers like Anthropic and OpenAI cache prompts based on exact prefix matc
 
 ## Configuration
 
-DCP uses its own config file (`~/.config/opencode/dcp.jsonc` or `.opencode/dcp.jsonc`), created automatically on first run.
+DCP uses its own config file:
+
+- Global: `~/.config/opencode/dcp.jsonc` (or `dcp.json`), created automatically on first run
+- Custom config directory: `$OPENCODE_CONFIG_DIR/dcp.jsonc` (or `dcp.json`), if `OPENCODE_CONFIG_DIR` is set
+- Project: `.opencode/dcp.jsonc` (or `dcp.json`) in your project’s `.opencode` directory
 
 <details>
 <summary><strong>Default Configuration</strong> (click to expand)</summary>
@@ -104,7 +108,9 @@ The `protectedTools` arrays in each strategy add to this default list.
 
 ### Config Precedence
 
-Settings are merged in order: **Defaults** → **Global** (`~/.config/opencode/dcp.jsonc`) → **Project** (`.opencode/dcp.jsonc`). Each level overrides the previous, so project settings take priority over global, which takes priority over defaults.
+Settings are merged in order:
+Defaults → Global (`~/.config/opencode/dcp.jsonc`) → Config Dir (`$OPENCODE_CONFIG_DIR/dcp.jsonc`) → Project (`.opencode/dcp.jsonc`).
+Each level overrides the previous, so project settings take priority over config-dir and global, which take priority over defaults.
 
 Restart OpenCode after making config changes.
 


### PR DESCRIPTION
**Summary**
This PR (updated from PR #112 to latest dev branch rebase)  adds support for loading DCP config from $OPENCODE_CONFIG_DIR/dcp.jsonc (or dcp.json), aligning the plugin with OpenCode’s custom config directory behavior.

**Details**
   - `lib/config.ts`:
        - Extends `getConfigPaths` to also resolve a config path from $OPENCODE_CONFIG_DIR/dcp.jsonc` or `dcp.json` when `OPENCODE_CONFIG_DIR is set.
        - `getConfig` now merges config in this order:
            - Defaults
            - Global: `~/.config/opencode/dcp.jsonc`
            - Config dir: `$OPENCODE_CONFIG_DIR/dcp.jsonc`
            - Project: `.opencode/dcp.jsonc`
    - Global config behavior is unchanged:
        - `~/.config/opencode/dcp.jsonc` is still created automatically on first run.
        - No config file is created under `OPENCODE_CONFIG_DIR`.

This makes DCP configuration placement align with OpenCode’s OPENCODE_CONFIG_DIR behavior, without changing any existing defaults or project-level overrides.
