### PR TITLE
fix: skip inserting prunable tools list when empty

### DIFF
--- a/lib/messages/prune.ts
+++ b/lib/messages/prune.ts
@@ -33,6 +33,10 @@ const buildPrunableToolsList = (
         logger.debug(`Prunable tool found - ID: ${numericId}, Tool: ${toolParameterEntry.tool}, Call ID: ${toolCallId}`)
     })
 
+    if (lines.length === 0) {
+        return ""
+    }
+
     return `<prunable-tools>\nThe following tools have been invoked and are available for pruning. This list does not mandate immediate action. Consider your current goals and the resources you need before discarding valuable tool outputs. Keep the context free of noise.\n${lines.join('\n')}\n</prunable-tools>`
 }
 
@@ -52,6 +56,9 @@ export const insertPruneToolContext = (
     }
 
     const prunableToolsList = buildPrunableToolsList(state, config, logger, messages)
+    if (!prunableToolsList) {
+        return
+    }
 
     let nudgeString = ""
     if (state.nudgeCounter >= config.strategies.pruneTool.nudge.frequency) {


### PR DESCRIPTION
## Summary
- Fixes bug where empty `<prunable-tools>` XML block was inserted into context even when there were no tools to prune