### PR TITLE
v1.0.0 - Major Architecture Rewrite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tarquinen/opencode-dcp",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tarquinen/opencode-dcp",
-      "version": "1.0.0-beta.2",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.28",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@tarquinen/opencode-dcp",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0",
   "type": "module",
   "description": "OpenCode plugin that optimizes token usage by pruning obsolete tool outputs from conversation context",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Major rewrite to use OpenCode's native hooks API, removing provider-specific fetch wrapper code and dramatically simplifying the architecture.

## Highlights

- **Complete architecture rewrite** using `experimental.chat.messages.transform` and `experimental.chat.system.transform` hooks
- **Removed ~1,400 lines** of provider-specific format handlers (Anthropic, Bedrock, Gemini, OpenAI)
- **New features**: System prompt transformation, AI nudge system, custom config path support
- **Prune tool enabled by default** for more aggressive context management

## What's Changed

### Architecture
- Removed `lib/fetch-wrapper/` directory with 6+ format adapters
- Simplified state management, removed ID mapping layer
- Consolidated tool cache logic

### New Features
- System prompt transformation hook for synthetic context injection
- AI nudge system reminds LLM to use prune tool after N tool results
- Support for `$OPENCODE_CONFIG_DIR` config location

### Bug Fixes
- Skip inserting prunable tools list when empty
- Properly reset nudge counter after prune tool use
- Await session state load before syncing tool cache
- Prevent compacted tools from appearing in prunable list

### Breaking Changes
- On-idle strategy now marked as legacy and disabled by default

**Full Changelog**: https://github.com/Opencode-DCP/opencode-dynamic-context-pruning/compare/v0.4.17...v1.0.0