### PR TITLE
Simplify pruning notification label

### DIFF
--- a/lib/ui/notification.ts
+++ b/lib/ui/notification.ts
@@ -45,7 +45,7 @@ function buildDetailedMessage(
     if (pruneToolIds.length > 0) {
         const pruneTokenCounterStr = `~${formatTokenCount(state.stats.pruneTokenCounter)}`
         const reasonLabel = reason ? ` — ${PRUNE_REASON_LABELS[reason]}` : ''
-        message += `\n\n▣ Pruned tools (${pruneTokenCounterStr})${reasonLabel}`
+        message += `\n\n▣ Pruning (${pruneTokenCounterStr})${reasonLabel}`
 
         const itemLines = formatPrunedItemsList(pruneToolIds, toolMetadata, workingDirectory)
         message += '\n' + itemLines.join('\n')


### PR DESCRIPTION
## Summary
- Simplify the pruning notification label from "Pruned tools" to "Pruning" for cleaner UI