### PR TITLE
Restore showUpdateToasts config for backwards compat

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -46,6 +46,7 @@ export const VALID_CONFIG_KEYS = new Set([
     // Top-level keys
     'enabled',
     'debug',
+    'showUpdateToasts', // Deprecated but kept for backwards compatibility
     'pruningSummary',
     'strategies',
     // strategies.deduplication


### PR DESCRIPTION
## Summary
- Restores `showUpdateToasts` as a valid config key for backwards compatibility
- Marked as deprecated in the comment