### PR TITLE
Encourage consolidated pruning guidance

### DIFF
--- a/lib/messages/prune.ts
+++ b/lib/messages/prune.ts
@@ -11,7 +11,7 @@ const PRUNED_TOOL_OUTPUT_REPLACEMENT = '[Output removed to save context - inform
 const NUDGE_STRING = loadPrompt("nudge")
 
 const wrapPrunableTools = (content: string): string => `<prunable-tools>
-The following tools have been invoked and are available for pruning. This list does not mandate immediate action. Consider your current goals and the resources you need before discarding valuable tool inputs or outputs. Keep the context free of noise.
+The following tools have been invoked and are available for pruning. This list does not mandate immediate action. Consider your current goals and the resources you need before discarding valuable tool inputs or outputs. Consolidate your prunes for efficiency; it is rarely worth pruning a single tiny tool output. Keep the context free of noise.
 ${content}
 </prunable-tools>`
 const PRUNABLE_TOOLS_COOLDOWN = `<prunable-tools>

--- a/lib/prompts/synthetic.txt
+++ b/lib/prompts/synthetic.txt
@@ -4,8 +4,8 @@
 ENVIRONMENT
 You are operating in a context-constrained environment and thus must proactively manage your context window using the `prune` tool. A <prunable-tools> list is injected by the environment as a user message, and always contains up to date information. Use this information when deciding what to prune.
 
-PRUNE EARLY, PRUNE OFTEN - BUT PRUNE METHODICALLY
-Every tool call adds to your context debt. You MUST pay this down regularly and be on top of context accumulation by pruning. Evaluate what SHOULD be pruned before jumping the gun.
+PRUNE METHODICALLY - CONSOLIDATE YOUR ACTIONS
+Every tool call adds to your context debt. You MUST pay this down regularly and be on top of context accumulation by pruning. Consolidate your prunes for efficiency; it is rarely worth pruning a single tiny tool output unless it is pure noise. Evaluate what SHOULD be pruned before jumping the gun.
 
 WHEN TO PRUNE? THE THREE SCENARIOS TO CONSIDER
 1. TASK COMPLETION: When work is done, quietly prune the tools that aren't needed anymore
@@ -26,7 +26,7 @@ You MUST NOT prune when:
 Pruning that forces you to re-call the same tool later is a net loss. Only prune when you're confident the information won't be needed again.
 
 NOTES
-When in doubt, keep it. Prune often yet remain strategic about it.
+When in doubt, keep it. Prune frequently yet remain strategic and consolidate your actions.
 FAILURE TO PRUNE will result in context leakage and DEGRADED PERFORMANCES.
 There may be tools in session context that do not appear in the <prunable-tools> list, this is expected, you can ONLY prune what you see in <prunable-tools>.
 

--- a/lib/prompts/tool.txt
+++ b/lib/prompts/tool.txt
@@ -31,7 +31,8 @@ You must use this tool in three specific scenarios. The rules for distillation (
    - **Prefer keeping over re-fetching:** If uncertain whether you'll need the output again, keep it. The cost of retaining context is lower than the cost of redundant tool calls.
 
 ## Best Practices
-- **Don't wait too long:** Prune frequently to keep the context agile.
+- **Consolidate your prunes:** Don't prune a single small tool output (like a short bash command) unless it's pure noise. Wait until you have several items or a few large outputs to prune. Aim for high-impact prunes that significantly reduce context size or noise.
+- **Don't wait too long:** Prune frequently to keep the context agile, but balance this with the need for consolidation.
 - **Be surgical:** You can mix strategies. Prune noise without comment, while distilling useful context in the same turn.
 - **Verify:** Ensure you have captured what you need before deleting useful raw data.
 - **Think ahead:** Before pruning, ask: "Will I need this output for an upcoming task?" If you researched a file you'll later edit, or gathered context for implementation, do NOT prune it—even if you've distilled findings. Distillation captures *knowledge*; implementation requires *context*.


### PR DESCRIPTION
## Summary
- Updated pruning instructions in `tool.txt` and `synthetic.txt` to emphasize consolidation over frequent, small prunes.
- Modified the injected `<prunable-tools>` message in `prune.ts` to discourage pruning single tiny tool outputs.
- Replaced "batch" terminology with "consolidate" to avoid confusion with the project's separate `batch` tool.