### PR TITLE
Fix edit tool pruning to use correct field names

### DIFF
--- a/lib/messages/prune.ts
+++ b/lib/messages/prune.ts
@@ -206,8 +206,17 @@ const pruneToolInputs = (
                 continue
             }
 
-            if (part.state.input?.content !== undefined) {
+            // Write tool has content field, edit tool has oldString/newString fields
+            if (part.tool === 'write' && part.state.input?.content !== undefined) {
                 part.state.input.content = PRUNED_TOOL_INPUT_REPLACEMENT
+            }
+            if (part.tool === 'edit') {
+                if (part.state.input?.oldString !== undefined) {
+                    part.state.input.oldString = PRUNED_TOOL_INPUT_REPLACEMENT
+                }
+                if (part.state.input?.newString !== undefined) {
+                    part.state.input.newString = PRUNED_TOOL_INPUT_REPLACEMENT
+                }
             }
         }
     }

--- a/lib/strategies/utils.ts
+++ b/lib/strategies/utils.ts
@@ -55,12 +55,23 @@ export const calculateTokensSaved = (
                 }
                 // For write and edit tools, count input content as that is all we prune for these tools
                 // (input is present in both completed and error states)
-                if (part.tool === "write" || part.tool === "edit") {
+                if (part.tool === "write") {
                     const inputContent = part.state.input?.content
                     const content = typeof inputContent === 'string'
                         ? inputContent
                         : JSON.stringify(inputContent ?? '')
                     contents.push(content)
+                    continue
+                }
+                if (part.tool === "edit") {
+                    const oldString = part.state.input?.oldString
+                    const newString = part.state.input?.newString
+                    if (typeof oldString === 'string') {
+                        contents.push(oldString)
+                    }
+                    if (typeof newString === 'string') {
+                        contents.push(newString)
+                    }
                     continue
                 }
                 // For other tools, count output or error based on status


### PR DESCRIPTION
## Summary
- Fix edit tool pruning to target `oldString`/`newString` fields instead of non-existent `content` field
- Ensures edit operations are properly pruned when context management runs