### PR TITLE
Add line range info to read tool display

### DIFF
--- a/lib/messages/utils.ts
+++ b/lib/messages/utils.ts
@@ -70,6 +70,17 @@ export const extractParameterKey = (tool: string, parameters: any): string => {
     if (!parameters) return ""
 
     if (tool === "read" && parameters.filePath) {
+        const offset = parameters.offset
+        const limit = parameters.limit
+        if (offset !== undefined && limit !== undefined) {
+            return `${parameters.filePath} (lines ${offset}-${offset + limit})`
+        }
+        if (offset !== undefined) {
+            return `${parameters.filePath} (lines ${offset}+)`
+        }
+        if (limit !== undefined) {
+            return `${parameters.filePath} (lines 0-${limit})`
+        }
         return parameters.filePath
     }
     if (tool === "write" && parameters.filePath) {


### PR DESCRIPTION
## Summary
- Display line offset/limit info in read tool parameter key (e.g., `file.ts (lines 10-50)`)
- Improves visibility when partial file reads are performed