### PR TITLE
feat: add skill tool support to extractParameterKey

### DIFF
--- a/lib/messages/utils.ts
+++ b/lib/messages/utils.ts
@@ -137,6 +137,9 @@ export const extractParameterKey = (tool: string, parameters: any): string => {
     if (tool === "task" && parameters.description) {
         return parameters.description
     }
+    if (tool === "skill" && parameters.name) {
+        return parameters.name
+    }
 
     const paramStr = JSON.stringify(parameters)
     if (paramStr === "{}" || paramStr === "[]" || paramStr === "null") {


### PR DESCRIPTION
## Summary
- Add handler for the new `skill` tool in `extractParameterKey` to display the skill name in prunable tools list and notifications