### PR TITLE
fix: disable pruning of write/edit tools by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ DCP uses its own config file:
         },
         // Prune write tool inputs when the file has been subsequently read
         "supersedeWrites": {
-            "enabled": true,
+            "enabled": false,
         },
         // Prune tool inputs for errored tools after X turns
         "purgeErrors": {
@@ -129,7 +129,7 @@ When enabled, turn protection prevents tool outputs from being pruned for a conf
 ### Protected Tools
 
 By default, these tools are always protected from pruning across all strategies:
-`task`, `todowrite`, `todoread`, `discard`, `extract`, `batch`
+`task`, `todowrite`, `todoread`, `discard`, `extract`, `batch`, `write`, `edit`
 
 The `protectedTools` arrays in each section add to this default list.
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -58,7 +58,16 @@ export interface PluginConfig {
     }
 }
 
-const DEFAULT_PROTECTED_TOOLS = ["task", "todowrite", "todoread", "discard", "extract", "batch"]
+const DEFAULT_PROTECTED_TOOLS = [
+    "task",
+    "todowrite",
+    "todoread",
+    "discard",
+    "extract",
+    "batch",
+    "write",
+    "edit",
+]
 
 // Valid config keys for validation against user config
 export const VALID_CONFIG_KEYS = new Set([
@@ -382,7 +391,7 @@ const defaultConfig: PluginConfig = {
             protectedTools: [...DEFAULT_PROTECTED_TOOLS],
         },
         supersedeWrites: {
-            enabled: true,
+            enabled: false,
         },
         purgeErrors: {
             enabled: true,
@@ -502,7 +511,7 @@ function createDefaultConfig(): void {
     },
     // Prune write tool inputs when the file has been subsequently read
     "supersedeWrites": {
-      "enabled": true
+      "enabled": false
     },
     // Prune tool inputs for errored tools after X turns
     "purgeErrors": {

--- a/lib/messages/prune.ts
+++ b/lib/messages/prune.ts
@@ -43,6 +43,10 @@ const pruneToolOutputs = (state: SessionState, logger: Logger, messages: WithPar
     }
 }
 
+// NOTE: This function is currently unused because "write" and "edit" are protected by default.
+// Some models incorrectly use PRUNED_TOOL_INPUT_REPLACEMENT in their output when they see it in context.
+// See: https://github.com/Opencode-DCP/opencode-dynamic-context-pruning/issues/215
+// Keeping this function in case the bug is resolved in the future.
 const pruneToolInputs = (state: SessionState, logger: Logger, messages: WithParts[]): void => {
     for (const msg of messages) {
         if (isMessageCompacted(state, msg)) {


### PR DESCRIPTION
- Adds `write` and `edit` to default protected tools
- Disables `supersedeWrites` strategy by default

Fixes #215