### PR TITLE
fix: skip DCP injection for internal agents

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -30,6 +30,21 @@ const plugin: Plugin = (async (ctx) => {
             _input: unknown,
             output: { system: string[] },
         ) => {
+            const systemText = output.system.join("\n")
+            const internalAgentSignatures = [
+                "You are a title generator",
+                "You are a helpful AI assistant tasked with summarizing conversations",
+                "Summarize what was done in this conversation",
+            ]
+            if (internalAgentSignatures.some((sig) => systemText.includes(sig))) {
+                logger.info("Skipping DCP injection for internal agent")
+                state.isInternalAgent = true
+                return
+            }
+
+            // Reset flag for normal sessions
+            state.isInternalAgent = false
+
             const discardEnabled = config.tools.discard.enabled
             const extractEnabled = config.tools.extract.enabled
 

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -15,7 +15,7 @@ export function createChatMessageTransformHandler(
     return async (input: {}, output: { messages: WithParts[] }) => {
         await checkSession(client, state, logger, output.messages)
 
-        if (state.isSubAgent) {
+        if (state.isSubAgent || state.isInternalAgent) {
             return
         }
 

--- a/lib/state/state.ts
+++ b/lib/state/state.ts
@@ -43,6 +43,7 @@ export function createSessionState(): SessionState {
     return {
         sessionId: null,
         isSubAgent: false,
+        isInternalAgent: false,
         prune: {
             toolIds: [],
         },
@@ -61,6 +62,7 @@ export function createSessionState(): SessionState {
 export function resetSessionState(state: SessionState): void {
     state.sessionId = null
     state.isSubAgent = false
+    state.isInternalAgent = false
     state.prune = {
         toolIds: [],
     }

--- a/lib/state/types.ts
+++ b/lib/state/types.ts
@@ -12,7 +12,7 @@ export interface ToolParameterEntry {
     parameters: any
     status?: ToolStatus
     error?: string
-    turn: number // Which turn (step-start count) this tool was called on
+    turn: number
 }
 
 export interface SessionStats {
@@ -27,11 +27,12 @@ export interface Prune {
 export interface SessionState {
     sessionId: string | null
     isSubAgent: boolean
+    isInternalAgent: boolean
     prune: Prune
     stats: SessionStats
     toolParameters: Map<string, ToolParameterEntry>
     nudgeCounter: number
     lastToolPrune: boolean
     lastCompaction: number
-    currentTurn: number // Current turn count derived from step-start parts
+    currentTurn: number
 }


### PR DESCRIPTION
- Detect internal agent sessions (title, summary, compaction) by their system prompt signatures
- Skip injecting context management prompts for these sessions

Fixes #218