### PR TITLE
fix: remove isInternalAgent flag due to hook ordering race condition

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -37,13 +37,9 @@ const plugin: Plugin = (async (ctx) => {
                 "Summarize what was done in this conversation",
             ]
             if (internalAgentSignatures.some((sig) => systemText.includes(sig))) {
-                logger.info("Skipping DCP injection for internal agent")
-                state.isInternalAgent = true
+                logger.info("Skipping DCP system prompt injection for internal agent")
                 return
             }
-
-            // Reset flag for normal sessions
-            state.isInternalAgent = false
 
             const discardEnabled = config.tools.discard.enabled
             const extractEnabled = config.tools.extract.enabled

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -15,7 +15,7 @@ export function createChatMessageTransformHandler(
     return async (input: {}, output: { messages: WithParts[] }) => {
         await checkSession(client, state, logger, output.messages)
 
-        if (state.isSubAgent || state.isInternalAgent) {
+        if (state.isSubAgent) {
             return
         }
 

--- a/lib/state/state.ts
+++ b/lib/state/state.ts
@@ -43,7 +43,6 @@ export function createSessionState(): SessionState {
     return {
         sessionId: null,
         isSubAgent: false,
-        isInternalAgent: false,
         prune: {
             toolIds: [],
         },
@@ -63,7 +62,6 @@ export function createSessionState(): SessionState {
 export function resetSessionState(state: SessionState): void {
     state.sessionId = null
     state.isSubAgent = false
-    state.isInternalAgent = false
     state.prune = {
         toolIds: [],
     }

--- a/lib/state/types.ts
+++ b/lib/state/types.ts
@@ -27,7 +27,6 @@ export interface Prune {
 export interface SessionState {
     sessionId: string | null
     isSubAgent: boolean
-    isInternalAgent: boolean
     prune: Prune
     stats: SessionStats
     toolParameters: Map<string, ToolParameterEntry>


### PR DESCRIPTION
- Removes the `isInternalAgent` flag from session state
- Fixes race condition where concurrent internal agents (title/summary generators) would cause the prunable-tools list to not be injected

The `messages.transform` hook runs **before** `system.transform`, but we were setting `isInternalAgent` in `system.transform`. When concurrent internal agents ran, the flag would be stale by the time the next normal session's `messages.transform` checked it, causing it to skip `insertPruneToolContext()`.

Need a better solution to stop injections for internal agents