### PR TITLE
chore: bump version to 1.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tarquinen/opencode-dcp",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tarquinen/opencode-dcp",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "license": "MIT",
             "dependencies": {
                 "@opencode-ai/sdk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "@tarquinen/opencode-dcp",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "type": "module",
     "description": "OpenCode plugin that optimizes token usage by pruning obsolete tool outputs from conversation context",
     "main": "./dist/index.js",


### PR DESCRIPTION
Bump version to 1.1.4 following the isInternalAgent fix.