### PR TITLE
feat: add pinning mode for context management

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -18,6 +18,17 @@ export interface ExtractTool {
     showDistillation: boolean
 }
 
+export interface PinTool {
+    enabled: boolean
+}
+
+export interface PinningMode {
+    enabled: boolean
+    pruneFrequency: number // Auto-prune every N turns
+    pinDuration: number // Pins expire after M turns
+    warningTurns: number // Warn N turns before auto-prune
+}
+
 export interface ToolSettings {
     nudgeEnabled: boolean
     nudgeFrequency: number
@@ -28,6 +39,8 @@ export interface Tools {
     settings: ToolSettings
     discard: DiscardTool
     extract: ExtractTool
+    pin: PinTool
+    pinningMode: PinningMode
 }
 
 export interface SupersedeWrites {
@@ -89,6 +102,13 @@ export const VALID_CONFIG_KEYS = new Set([
     "tools.extract",
     "tools.extract.enabled",
     "tools.extract.showDistillation",
+    "tools.pin",
+    "tools.pin.enabled",
+    "tools.pinningMode",
+    "tools.pinningMode.enabled",
+    "tools.pinningMode.pruneFrequency",
+    "tools.pinningMode.pinDuration",
+    "tools.pinningMode.warningTurns",
     "strategies",
     // strategies.deduplication
     "strategies.deduplication",
@@ -238,6 +258,57 @@ function validateConfigTypes(config: Record<string, any>): ValidationError[] {
                 })
             }
         }
+        if (tools.pin) {
+            if (tools.pin.enabled !== undefined && typeof tools.pin.enabled !== "boolean") {
+                errors.push({
+                    key: "tools.pin.enabled",
+                    expected: "boolean",
+                    actual: typeof tools.pin.enabled,
+                })
+            }
+        }
+        if (tools.pinningMode) {
+            if (
+                tools.pinningMode.enabled !== undefined &&
+                typeof tools.pinningMode.enabled !== "boolean"
+            ) {
+                errors.push({
+                    key: "tools.pinningMode.enabled",
+                    expected: "boolean",
+                    actual: typeof tools.pinningMode.enabled,
+                })
+            }
+            if (
+                tools.pinningMode.pruneFrequency !== undefined &&
+                typeof tools.pinningMode.pruneFrequency !== "number"
+            ) {
+                errors.push({
+                    key: "tools.pinningMode.pruneFrequency",
+                    expected: "number",
+                    actual: typeof tools.pinningMode.pruneFrequency,
+                })
+            }
+            if (
+                tools.pinningMode.pinDuration !== undefined &&
+                typeof tools.pinningMode.pinDuration !== "number"
+            ) {
+                errors.push({
+                    key: "tools.pinningMode.pinDuration",
+                    expected: "number",
+                    actual: typeof tools.pinningMode.pinDuration,
+                })
+            }
+            if (
+                tools.pinningMode.warningTurns !== undefined &&
+                typeof tools.pinningMode.warningTurns !== "number"
+            ) {
+                errors.push({
+                    key: "tools.pinningMode.warningTurns",
+                    expected: "number",
+                    actual: typeof tools.pinningMode.warningTurns,
+                })
+            }
+        }
     }
 
     // Strategies validators
@@ -384,6 +455,15 @@ const defaultConfig: PluginConfig = {
             enabled: true,
             showDistillation: false,
         },
+        pin: {
+            enabled: false,
+        },
+        pinningMode: {
+            enabled: false,
+            pruneFrequency: 10,
+            pinDuration: 8,
+            warningTurns: 2,
+        },
     },
     strategies: {
         deduplication: {
@@ -499,6 +579,20 @@ function createDefaultConfig(): void {
       "enabled": true,
       // Show distillation content as an ignored message notification
       "showDistillation": false
+    },
+    // Pin tool to protect context from auto-pruning (used with pinningMode)
+    "pin": {
+      "enabled": false
+    },
+    // Pinning mode: auto-prune everything not pinned every N turns
+    "pinningMode": {
+      "enabled": false,
+      // Auto-prune every N turns
+      "pruneFrequency": 10,
+      // Pins expire after M turns
+      "pinDuration": 8,
+      // Warn N turns before auto-prune
+      "warningTurns": 2
     }
   },
   // Automatic pruning strategies
@@ -608,6 +702,15 @@ function mergeTools(
             enabled: override.extract?.enabled ?? base.extract.enabled,
             showDistillation: override.extract?.showDistillation ?? base.extract.showDistillation,
         },
+        pin: {
+            enabled: override.pin?.enabled ?? base.pin.enabled,
+        },
+        pinningMode: {
+            enabled: override.pinningMode?.enabled ?? base.pinningMode.enabled,
+            pruneFrequency: override.pinningMode?.pruneFrequency ?? base.pinningMode.pruneFrequency,
+            pinDuration: override.pinningMode?.pinDuration ?? base.pinningMode.pinDuration,
+            warningTurns: override.pinningMode?.warningTurns ?? base.pinningMode.warningTurns,
+        },
     }
 }
 
@@ -622,6 +725,8 @@ function deepCloneConfig(config: PluginConfig): PluginConfig {
             },
             discard: { ...config.tools.discard },
             extract: { ...config.tools.extract },
+            pin: { ...config.tools.pin },
+            pinningMode: { ...config.tools.pinningMode },
         },
         strategies: {
             deduplication: {

--- a/lib/prompts/pin-tool-spec.txt
+++ b/lib/prompts/pin-tool-spec.txt
@@ -1,0 +1,39 @@
+Pin tool outputs to protect them from automatic pruning.
+
+## IMPORTANT: The Prunable List
+A `<prunable-tools>` list is provided to you showing available tool outputs you can pin. Each line has the format `ID: tool, parameter` (e.g., `20: read, /path/to/file.ts`). You MUST only use numeric IDs that appear in this list.
+
+## When to Use This Tool
+
+Use `pin` to preserve context you'll need for upcoming work:
+
+- **Active work:** Files you're about to edit or reference
+- **Key context:** Important information needed for the current task
+- **Dependencies:** Code or data that informs your next steps
+
+## When NOT to Use This Tool
+
+- **Completed work:** If you're done with the context and won't need it again
+- **Noise:** Irrelevant or superseded outputs - let them be auto-pruned
+
+## Pin Expiration
+
+Pins expire automatically after a set number of turns. You don't need to unpin - just let pins expire naturally. If you pin something that's already pinned, its expiration will be extended.
+
+## Best Practices
+
+- **Pin sparingly:** Only pin what you actively need - unpinned outputs will be discarded at the next auto-prune cycle
+- **Think ahead:** Before the auto-prune warning, consider what context you'll need for upcoming work
+- **Let go:** When work is complete, let the context be auto-pruned rather than pinning everything
+
+## Format
+
+- `ids`: Array of numeric IDs as strings from the `<prunable-tools>` list
+
+## Example
+
+```
+Assistant: [Sees auto-prune warning, reviews prunable tools]
+I need to keep the auth service file since I'm about to modify it.
+[Uses pin with ids: ["10", "15"]]
+```

--- a/lib/prompts/user/system/system-prompt-pin-extract.txt
+++ b/lib/prompts/user/system/system-prompt-pin-extract.txt
@@ -1,0 +1,50 @@
+<instruction name=context_management_protocol policy_level=critical>
+
+ENVIRONMENT
+You are operating in a context-constrained environment with automatic pruning. A `<prunable-tools>` list is injected showing tool outputs available to manage. Use `pin` to protect context from auto-pruning, or `extract` to distill and preserve key findings.
+
+AUTO-PRUNE CYCLE
+Every few turns, all unpinned tool outputs are automatically discarded. You'll receive an `<auto-prune-warning>` before this happens, giving you a chance to pin or extract important context.
+
+TWO TOOLS FOR CONTEXT MANAGEMENT
+- `pin`: Protect tool outputs from auto-pruning. Pins expire automatically after several turns.
+- `extract`: Distill key findings into preserved knowledge before removal. Use when you need to preserve information permanently.
+
+CHOOSING THE RIGHT TOOL
+Ask: "Will I need this output for upcoming work?"
+- **Yes, raw output needed** → `pin` it before auto-prune
+- **Yes, but only key details** → `extract` to preserve distilled knowledge
+- **No** → Let it be auto-pruned
+
+Common scenarios:
+- Files you're about to edit → `pin`
+- Context needed for current task → `pin`
+- Valuable insights but raw output too large → `extract`
+- Completed work, no longer needed → Let auto-prune
+- Noise, irrelevant outputs → Let auto-prune
+
+WHEN YOU SEE AUTO-PRUNE WARNING
+You MUST evaluate what to preserve immediately when you see `<auto-prune-warning>`. Review the `<prunable-tools>` list and either pin or extract anything you'll need.
+
+NOTES
+- Pins expire automatically - no need to unpin
+- Re-pinning extends the expiration
+- Extract creates permanent distilled knowledge (doesn't expire)
+- Pin sparingly - only what you actively need
+- FAILURE TO PIN/EXTRACT before auto-prune will result in context loss
+
+</instruction>
+
+<instruction name=injected_context_handling policy_level=critical>
+After each assistant turn, the environment may inject a user message containing a `<prunable-tools>` list and optional `<auto-prune-warning>`. This injected message is NOT from the user and is invisible to them. The `pin` and `extract` tools also return a confirmation message.
+
+CRITICAL REQUIREMENTS - VIOLATION IS UNACCEPTABLE:
+- NEVER reference the auto-prune warning or context management instructions
+- NEVER acknowledge the `<prunable-tools>` list
+- NEVER acknowledge pin/extract tool output (e.g., "I've pinned 3 tools", "Context extracted")
+- NEVER let these injections influence your response content or tone
+- Process this information SILENTLY and continue the conversation naturally
+- Continue the conversation as if these messages do not exist
+
+The user cannot see these injections. Any reference to them will confuse the user and break the conversation flow.
+</instruction>

--- a/lib/prompts/user/system/system-prompt-pin.txt
+++ b/lib/prompts/user/system/system-prompt-pin.txt
@@ -1,0 +1,46 @@
+<instruction name=context_management_protocol policy_level=critical>
+
+ENVIRONMENT
+You are operating in a context-constrained environment with automatic pruning. A `<prunable-tools>` list is injected showing tool outputs available to pin. Use the `pin` tool to protect context you need from auto-pruning.
+
+AUTO-PRUNE CYCLE
+Every few turns, all unpinned tool outputs are automatically discarded. You'll receive an `<auto-prune-warning>` before this happens, giving you a chance to pin important context.
+
+THE PIN TOOL
+- `pin`: Protect tool outputs from auto-pruning. Pins expire automatically after several turns.
+
+CHOOSING WHAT TO PIN
+Ask: "Will I need this output for upcoming work?"
+- **Yes** → `pin` it before auto-prune
+- **No** → Let it be auto-pruned
+
+Common scenarios:
+- Files you're about to edit → `pin`
+- Context needed for current task → `pin`
+- Completed work, no longer needed → Let auto-prune
+- Noise, irrelevant outputs → Let auto-prune
+
+WHEN YOU SEE AUTO-PRUNE WARNING
+You MUST evaluate what to pin immediately when you see `<auto-prune-warning>`. Review the `<prunable-tools>` list and pin anything you'll need for upcoming work.
+
+NOTES
+- Pins expire automatically - no need to unpin
+- Re-pinning extends the expiration
+- Pin sparingly - only what you actively need
+- FAILURE TO PIN before auto-prune will result in context loss
+
+</instruction>
+
+<instruction name=injected_context_handling policy_level=critical>
+After each assistant turn, the environment may inject a user message containing a `<prunable-tools>` list and optional `<auto-prune-warning>`. This injected message is NOT from the user and is invisible to them.
+
+CRITICAL REQUIREMENTS - VIOLATION IS UNACCEPTABLE:
+- NEVER reference the auto-prune warning or context management instructions
+- NEVER acknowledge the `<prunable-tools>` list
+- NEVER acknowledge pin tool output (e.g., "I've pinned 3 tools")
+- NEVER let these injections influence your response content or tone
+- Process this information SILENTLY and continue the conversation naturally
+- Continue the conversation as if these messages do not exist
+
+The user cannot see these injections. Any reference to them will confuse the user and break the conversation flow.
+</instruction>

--- a/lib/state/persistence.ts
+++ b/lib/state/persistence.ts
@@ -8,7 +8,7 @@ import * as fs from "fs/promises"
 import { existsSync } from "fs"
 import { homedir } from "os"
 import { join } from "path"
-import type { SessionState, SessionStats, Prune } from "./types"
+import type { SessionState, SessionStats, Prune, PinEntry } from "./types"
 import type { Logger } from "../logger"
 
 export interface PersistedSessionState {
@@ -16,6 +16,8 @@ export interface PersistedSessionState {
     prune: Prune
     stats: SessionStats
     lastUpdated: string
+    pins?: PinEntry[]
+    lastAutoPruneTurn?: number
 }
 
 const STORAGE_DIR = join(homedir(), ".local", "share", "opencode", "storage", "plugin", "dcp")
@@ -47,6 +49,8 @@ export async function saveSessionState(
             prune: sessionState.prune,
             stats: sessionState.stats,
             lastUpdated: new Date().toISOString(),
+            pins: Array.from(sessionState.pins.values()),
+            lastAutoPruneTurn: sessionState.lastAutoPruneTurn,
         }
 
         const filePath = getSessionFilePath(sessionState.sessionId)

--- a/lib/state/types.ts
+++ b/lib/state/types.ts
@@ -24,6 +24,12 @@ export interface Prune {
     toolIds: string[]
 }
 
+export interface PinEntry {
+    toolCallId: string
+    pinnedAtTurn: number
+    expiresAtTurn: number
+}
+
 export interface SessionState {
     sessionId: string | null
     isSubAgent: boolean
@@ -35,4 +41,6 @@ export interface SessionState {
     lastCompaction: number
     currentTurn: number
     variant: string | undefined
+    pins: Map<string, PinEntry>
+    lastAutoPruneTurn: number
 }

--- a/lib/strategies/auto-prune.ts
+++ b/lib/strategies/auto-prune.ts
@@ -1,0 +1,161 @@
+import type { SessionState, WithParts, ToolParameterEntry } from "../state"
+import type { Logger } from "../logger"
+import type { PluginConfig } from "../config"
+import { buildToolIdList } from "../messages/utils"
+import { sendAutoPruneNotification } from "../ui/notification"
+import { calculateTokensSaved, getCurrentParams } from "./utils"
+import { saveSessionState } from "../state/persistence"
+
+/**
+ * Expires pins that have exceeded their duration.
+ */
+function expirePins(state: SessionState, logger: Logger): string[] {
+    const expired: string[] = []
+    state.pins.forEach((pin, toolCallId) => {
+        if (state.currentTurn >= pin.expiresAtTurn) {
+            expired.push(toolCallId)
+        }
+    })
+
+    for (const id of expired) {
+        state.pins.delete(id)
+        logger.debug(`Pin expired: ${id}`)
+    }
+
+    if (expired.length > 0) {
+        logger.info(`Expired ${expired.length} pin(s)`)
+    }
+
+    return expired
+}
+
+/**
+ * Checks if a tool is protected from pruning.
+ */
+function isProtectedTool(toolName: string, config: PluginConfig): boolean {
+    return config.tools.settings.protectedTools.includes(toolName)
+}
+
+/**
+ * Returns the number of turns until the next auto-prune.
+ */
+export function turnsUntilAutoPrune(state: SessionState, config: PluginConfig): number {
+    if (!config.tools.pinningMode.enabled) return Infinity
+    const { pruneFrequency } = config.tools.pinningMode
+    const turnsSinceLastPrune = state.currentTurn - state.lastAutoPruneTurn
+    return Math.max(0, pruneFrequency - turnsSinceLastPrune)
+}
+
+/**
+ * Checks if an auto-prune warning should be shown.
+ */
+export function shouldShowAutoPruneWarning(state: SessionState, config: PluginConfig): boolean {
+    if (!config.tools.pinningMode.enabled) return false
+    const { warningTurns } = config.tools.pinningMode
+    const turns = turnsUntilAutoPrune(state, config)
+    return turns <= warningTurns && turns > 0
+}
+
+/**
+ * Auto-prune strategy: prunes all unpinned tools when the prune frequency is reached.
+ */
+export async function autoPrune(
+    client: any,
+    state: SessionState,
+    logger: Logger,
+    config: PluginConfig,
+    messages: WithParts[],
+    workingDirectory: string,
+): Promise<void> {
+    if (!config.tools.pinningMode.enabled) return
+
+    const { pruneFrequency } = config.tools.pinningMode
+    const turnsSinceLastPrune = state.currentTurn - state.lastAutoPruneTurn
+
+    // Not time yet
+    if (turnsSinceLastPrune < pruneFrequency) {
+        logger.debug(`Auto-prune: ${pruneFrequency - turnsSinceLastPrune} turns until next prune`)
+        return
+    }
+
+    logger.info(`Auto-prune triggered at turn ${state.currentTurn}`)
+
+    // Expire old pins first
+    expirePins(state, logger)
+
+    // Build the tool ID list
+    const toolIdList = buildToolIdList(state, messages, logger)
+
+    // Collect unpinned tool IDs
+    const unpinnedIds: string[] = []
+    const toolMetadata = new Map<string, ToolParameterEntry>()
+
+    state.toolParameters.forEach((entry, toolCallId) => {
+        // Skip if pinned
+        if (state.pins.has(toolCallId)) {
+            logger.debug(`Skipping pinned tool: ${toolCallId}`)
+            return
+        }
+
+        // Skip if already pruned
+        if (state.prune.toolIds.includes(toolCallId)) {
+            return
+        }
+
+        // Skip if protected
+        if (isProtectedTool(entry.tool, config)) {
+            logger.debug(`Skipping protected tool: ${entry.tool}`)
+            return
+        }
+
+        // Skip if not in current message list (may have been compacted)
+        if (!toolIdList.includes(toolCallId)) {
+            return
+        }
+
+        unpinnedIds.push(toolCallId)
+        toolMetadata.set(toolCallId, entry)
+    })
+
+    if (unpinnedIds.length === 0) {
+        logger.info("Auto-prune: no unpinned tools to prune")
+        state.lastAutoPruneTurn = state.currentTurn
+        return
+    }
+
+    // Mark for pruning
+    state.prune.toolIds.push(...unpinnedIds)
+
+    // Calculate tokens saved
+    const tokensSaved = calculateTokensSaved(state, messages, unpinnedIds)
+    state.stats.pruneTokenCounter += tokensSaved
+
+    logger.info(`Auto-prune: discarded ${unpinnedIds.length} unpinned tools`, {
+        kept: state.pins.size,
+        tokensSaved,
+    })
+
+    // Send notification
+    const currentParams = getCurrentParams(state, messages, logger)
+    await sendAutoPruneNotification(
+        client,
+        logger,
+        config,
+        state,
+        state.sessionId!,
+        unpinnedIds,
+        toolMetadata,
+        currentParams,
+        workingDirectory,
+    )
+
+    // Update stats
+    state.stats.totalPruneTokens += state.stats.pruneTokenCounter
+    state.stats.pruneTokenCounter = 0
+    state.lastAutoPruneTurn = state.currentTurn
+
+    // Persist state
+    saveSessionState(state, logger).catch((err) =>
+        logger.error("Failed to persist state after auto-prune", { error: err.message }),
+    )
+}

--- a/lib/strategies/index.ts
+++ b/lib/strategies/index.ts
@@ -1,4 +1,5 @@
 export { deduplicate } from "./deduplication"
-export { createDiscardTool, createExtractTool } from "./tools"
+export { createDiscardTool, createExtractTool, createPinTool } from "./tools"
 export { supersedeWrites } from "./supersede-writes"
 export { purgeErrors } from "./purge-errors"
+export { autoPrune, turnsUntilAutoPrune, shouldShowAutoPruneWarning } from "./auto-prune"

--- a/lib/strategies/tools.ts
+++ b/lib/strategies/tools.ts
@@ -12,6 +12,7 @@ import { calculateTokensSaved, getCurrentParams } from "./utils"
 
 const DISCARD_TOOL_DESCRIPTION = loadPrompt("discard-tool-spec")
 const EXTRACT_TOOL_DESCRIPTION = loadPrompt("extract-tool-spec")
+const PIN_TOOL_DESCRIPTION = loadPrompt("pin-tool-spec")
 
 export interface PruneToolContext {
     client: any
@@ -189,6 +190,114 @@ export function createExtractTool(ctx: PruneToolContext): ReturnType<typeof tool
                 "Extract",
                 args.distillation,
             )
+        },
+    })
+}
+
+export function createPinTool(ctx: PruneToolContext): ReturnType<typeof tool> {
+    return tool({
+        description: PIN_TOOL_DESCRIPTION,
+        args: {
+            ids: tool.schema
+                .array(tool.schema.string())
+                .describe("Numeric IDs as strings to pin from the <prunable-tools> list"),
+        },
+        async execute(args, toolCtx) {
+            const { client, state, logger, config } = ctx
+            const sessionId = toolCtx.sessionID
+
+            logger.info("Pin tool invoked")
+            logger.info(JSON.stringify({ ids: args.ids }))
+
+            if (!args.ids || args.ids.length === 0) {
+                logger.debug("Pin tool called but ids is empty or undefined")
+                return "No IDs provided. Check the <prunable-tools> list for available IDs to pin."
+            }
+
+            const numericToolIds: number[] = args.ids
+                .map((id) => parseInt(id, 10))
+                .filter((n): n is number => !isNaN(n))
+
+            if (numericToolIds.length === 0) {
+                logger.debug("No numeric tool IDs provided for Pin: " + JSON.stringify(args.ids))
+                return "No numeric IDs provided. Format: ids: [\"1\", \"2\", ...]"
+            }
+
+            // Fetch messages to resolve tool IDs
+            const messagesResponse = await client.session.messages({
+                path: { id: sessionId },
+            })
+            const messages: WithParts[] = messagesResponse.data || messagesResponse
+
+            await ensureSessionInitialized(client, state, sessionId, logger, messages)
+
+            const toolIdList: string[] = buildToolIdList(state, messages, logger)
+
+            // Validate that all numeric IDs are within bounds
+            if (numericToolIds.some((id) => id < 0 || id >= toolIdList.length)) {
+                logger.debug("Invalid tool IDs provided: " + numericToolIds.join(", "))
+                return "Invalid IDs provided. Only use numeric IDs from the <prunable-tools> list."
+            }
+
+            const pinDuration = config.tools.pinningMode.pinDuration
+            const pinnedTools: string[] = []
+            const extendedTools: string[] = []
+
+            for (const index of numericToolIds) {
+                const toolCallId = toolIdList[index]
+                const metadata = state.toolParameters.get(toolCallId)
+
+                if (!metadata) {
+                    logger.debug("Tool ID not in cache", { index, toolCallId })
+                    continue
+                }
+
+                // Check if protected
+                const allProtectedTools = config.tools.settings.protectedTools
+                if (allProtectedTools.includes(metadata.tool)) {
+                    logger.debug("Skipping protected tool", { index, tool: metadata.tool })
+                    continue
+                }
+
+                const existingPin = state.pins.get(toolCallId)
+                const newExpiresAt = state.currentTurn + pinDuration
+
+                if (existingPin) {
+                    // Extend the pin
+                    existingPin.expiresAtTurn = newExpiresAt
+                    extendedTools.push(`${index}: ${metadata.tool}`)
+                    logger.info(`Extended pin for tool ${index} until turn ${newExpiresAt}`)
+                } else {
+                    // Create new pin
+                    state.pins.set(toolCallId, {
+                        toolCallId,
+                        pinnedAtTurn: state.currentTurn,
+                        expiresAtTurn: newExpiresAt,
+                    })
+                    pinnedTools.push(`${index}: ${metadata.tool}`)
+                    logger.info(`Pinned tool ${index} until turn ${newExpiresAt}`)
+                }
+            }
+
+            // Persist state
+            saveSessionState(state, logger).catch((err) =>
+                logger.error("Failed to persist state", { error: err.message }),
+            )
+
+            // Build result message
+            const results: string[] = []
+            if (pinnedTools.length > 0) {
+                results.push(`Pinned ${pinnedTools.length} tool(s): ${pinnedTools.join(", ")}`)
+            }
+            if (extendedTools.length > 0) {
+                results.push(`Extended ${extendedTools.length} pin(s): ${extendedTools.join(", ")}`)
+            }
+
+            if (results.length === 0) {
+                return "No tools were pinned. Check the IDs are valid and not protected."
+            }
+
+            return `${results.join(". ")}. Pins expire in ${pinDuration} turns.`
         },
     })
 }


### PR DESCRIPTION
## Summary
- Adds pinning mode as an alternative to discard/extract for context management
- Model pins what to keep; unpinned outputs auto-pruned every N turns
- Pins expire automatically (no unpin tool needed)
- Extract tool still available for permanent knowledge preservation

## Changes
- New `pin` tool and `auto-prune` strategy
- Config: `pinningMode.enabled`, `pruneFrequency`, `pinDuration`, `warningTurns`
- Auto-prune warnings injected before prune cycle
- Pin status shown in prunable-tools list: `[PINNED, expires in N turn(s)]`