### PR TITLE
docs: document subagent limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ Each level overrides the previous, so project settings take priority over config
 
 Restart OpenCode after making config changes.
 
+## Limitations
+
+**Subagents** — DCP is disabled for subagents. Subagents are not designed to be token efficient; what matters is that the final message returned to the main agent is a concise summary of findings. DCP's pruning could interfere with this summarization behavior.
+
 ## License
 
 MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tarquinen/opencode-dcp",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tarquinen/opencode-dcp",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "license": "MIT",
             "dependencies": {
                 "@opencode-ai/sdk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "@tarquinen/opencode-dcp",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "type": "module",
     "description": "OpenCode plugin that optimizes token usage by pruning obsolete tool outputs from conversation context",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Documents that DCP is disabled for subagents in the README
- Bumps version to 1.1.5

Closes #232