### PR TITLE
fix: use master branch in schema URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ DCP uses its own config file:
 
 ```jsonc
 {
+    "$schema": "https://raw.githubusercontent.com/Opencode-DCP/opencode-dynamic-context-pruning/master/dcp.schema.json",
     // Enable or disable the plugin
     "enabled": true,
     // Enable debug logging to ~/.config/opencode/logs/dcp/

--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/Opencode-DCP/opencode-dynamic-context-pruning/main/dcp.schema.json",
+    "$id": "https://raw.githubusercontent.com/Opencode-DCP/opencode-dynamic-context-pruning/master/dcp.schema.json",
     "title": "DCP Plugin Configuration",
     "description": "Configuration schema for the OpenCode Dynamic Context Pruning plugin",
     "type": "object",

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -488,7 +488,7 @@ function createDefaultConfig(): void {
     }
 
     const configContent = `{
-  "$schema": "https://raw.githubusercontent.com/Opencode-DCP/opencode-dynamic-context-pruning/main/dcp.schema.json",
+  "$schema": "https://raw.githubusercontent.com/Opencode-DCP/opencode-dynamic-context-pruning/master/dcp.schema.json",
   // Enable or disable the plugin
   "enabled": true,
   // Enable debug logging to ~/.config/opencode/logs/dcp/


### PR DESCRIPTION
## Summary
- Update all schema URLs to use `master` instead of `main` to match the repository's default branch
- Add `$schema` to README default configuration example