### PR TITLE
wip: Synthetic msg copilot fix

### DIFF
--- a/lib/messages/inject.ts
+++ b/lib/messages/inject.ts
@@ -149,11 +149,16 @@ export const insertPruneToolContext = (
         injectionType: isGitHubCopilot ? "assistant-with-tool-part" : "user-message",
     })
 
+    const variant = state.variant ?? (lastUserMessage.info as UserMessage).variant
     if (isGitHubCopilot) {
         messages.push(
-            createSyntheticAssistantMessageWithToolPart(lastUserMessage, prunableToolsContent),
+            createSyntheticAssistantMessageWithToolPart(
+                lastUserMessage,
+                prunableToolsContent,
+                variant,
+            ),
         )
     } else {
-        messages.push(createSyntheticUserMessage(lastUserMessage, prunableToolsContent))
+        messages.push(createSyntheticUserMessage(lastUserMessage, prunableToolsContent, variant))
     }
 }

--- a/lib/messages/utils.ts
+++ b/lib/messages/utils.ts
@@ -41,6 +41,7 @@ export const createSyntheticUserMessage = (
 export const createSyntheticAssistantMessageWithToolPart = (
     baseMessage: WithParts,
     content: string,
+    variant?: string,
 ): WithParts => {
     const userInfo = baseMessage.info as UserMessage
     const now = Date.now()
@@ -61,6 +62,7 @@ export const createSyntheticAssistantMessageWithToolPart = (
             time: { created: now, completed: now },
             cost: 0,
             tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            ...(variant !== undefined && { variant }),
         },
         parts: [
             {


### PR DESCRIPTION
This PR addresses the new copilot crackdown and opencode moving to clocking every user message causing inference to count 1 premium request (if used with premium models ofc)

it uses an assistant message and toolpart to inject the DCP prunable tool list last in chain (replacing the user message injection)

This also changes reasoning model behavior, where they see this prunable tool list as a tool and not a user message, thus not reasoning about the prunable tool list itself, spending less reasoning budget on talking about DCP - theoretically, could boost model performances? anywho, it feels better with reasoning models in my limited tests (Opus 4.5 and GLM 4.7)