### PR TITLE
fix: skip synthetic message injection for GitHub Copilot when last message is user role

### DIFF
--- a/lib/messages/inject.ts
+++ b/lib/messages/inject.ts
@@ -143,6 +143,13 @@ export const insertPruneToolContext = (
     const isGitHubCopilot =
         providerID === "github-copilot" || providerID === "github-copilot-enterprise"
 
+    if (isGitHubCopilot) {
+        const lastMessage = messages[messages.length - 1]
+        if (lastMessage?.info?.role === "user") {
+            return
+        }
+    }
+
     logger.info("Injecting prunable-tools list", {
         providerID,
         isGitHubCopilot,


### PR DESCRIPTION
Adds early return in `insertPruneToolContext` to skip synthetic message injection when the provider is GitHub Copilot and the last message in the conversation is a user role
Fixes DCP significantly reducing copilot usage, expect usage to drain faster same as base opencode