### PR TITLE
feat: add plan_enter and plan_exit to default protected tools

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -68,6 +68,8 @@ const DEFAULT_PROTECTED_TOOLS = [
     "batch",
     "write",
     "edit",
+    "plan_enter",
+    "plan_exit",
 ]
 
 // Valid config keys for validation against user config


### PR DESCRIPTION
- Adds `plan_enter` and `plan_exit` to the default protected tools list
- These are experimental plan mode tools introduced in opencode v1.1.119 (behind `OPENCODE_EXPERIMENTAL_PLAN_MODE=1`)
- They have minimal outputs (~10-15 words), making pruning them counterproductive overhead