### PR TITLE
fix: simplify injection timing to wait for assistant turn

### DIFF
--- a/lib/messages/utils.ts
+++ b/lib/messages/utils.ts
@@ -207,23 +207,3 @@ export const isIgnoredUserMessage = (message: WithParts): boolean => {
 
     return true
 }
-
-export const hasReasoningInCurrentAssistantTurn = (messages: WithParts[]): boolean => {
-    for (let i = messages.length - 1; i >= 0; i--) {
-        const message = messages[i]
-        if (message.info?.role === "user") {
-            if (isIgnoredUserMessage(message)) {
-                continue
-            }
-            return false
-        }
-        if (message.info?.role === "assistant" && message.parts) {
-            for (const part of message.parts) {
-                if (part.type === "reasoning") {
-                    return true
-                }
-            }
-        }
-    }
-    return false
-}


### PR DESCRIPTION
## Summary
- Replace provider-specific injection checks (GitHub Copilot, Anthropic reasoning detection) with a universal rule
- Never inject immediately following a user message - wait until assistant has started its turn

Gemini reasoning models also require thinking blocks at the start of the turn, it seems like this is a pattern providers are sticking with so going to make it universal instead of checking provider to simplify