### PR TITLE
fix: use text injection for Gemini models to avoid thought signature errors

### DIFF
--- a/lib/messages/utils.ts
+++ b/lib/messages/utils.ts
@@ -7,6 +7,11 @@ const SYNTHETIC_MESSAGE_ID = "msg_01234567890123456789012345"
 const SYNTHETIC_PART_ID = "prt_01234567890123456789012345"
 const SYNTHETIC_CALL_ID = "call_01234567890123456789012345"
 
+const isGeminiModel = (modelID: string): boolean => {
+    const lowerModelID = modelID.toLowerCase()
+    return lowerModelID.includes("gemini")
+}
+
 export const createSyntheticAssistantMessageWithToolPart = (
     baseMessage: WithParts,
     content: string,
@@ -14,25 +19,46 @@ export const createSyntheticAssistantMessageWithToolPart = (
 ): WithParts => {
     const userInfo = baseMessage.info as UserMessage
     const now = Date.now()
-    return {
-        info: {
-            id: SYNTHETIC_MESSAGE_ID,
-            sessionID: userInfo.sessionID,
-            role: "assistant",
-            agent: userInfo.agent || "code",
-            parentID: userInfo.id,
-            modelID: userInfo.model.modelID,
-            providerID: userInfo.model.providerID,
-            mode: "default",
-            path: {
-                cwd: "/",
-                root: "/",
-            },
-            time: { created: now, completed: now },
-            cost: 0,
-            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-            ...(variant !== undefined && { variant }),
+
+    const baseInfo = {
+        id: SYNTHETIC_MESSAGE_ID,
+        sessionID: userInfo.sessionID,
+        role: "assistant" as const,
+        agent: userInfo.agent || "code",
+        parentID: userInfo.id,
+        modelID: userInfo.model.modelID,
+        providerID: userInfo.model.providerID,
+        mode: "default",
+        path: {
+            cwd: "/",
+            root: "/",
         },
+        time: { created: now, completed: now },
+        cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        ...(variant !== undefined && { variant }),
+    }
+
+    // For Gemini models, inject as text to avoid thought signature requirements
+    // Gemini 3+ has strict validation requiring thoughtSignature on functionCall parts
+    if (isGeminiModel(userInfo.model.modelID)) {
+        return {
+            info: baseInfo,
+            parts: [
+                {
+                    id: SYNTHETIC_PART_ID,
+                    sessionID: userInfo.sessionID,
+                    messageID: SYNTHETIC_MESSAGE_ID,
+                    type: "text",
+                    text: content,
+                },
+            ],
+        }
+    }
+
+    // For other models, use tool part for cleaner context
+    return {
+        info: baseInfo,
         parts: [
             {
                 id: SYNTHETIC_PART_ID,


### PR DESCRIPTION
## Summary
- Detect Gemini models and inject as text parts instead of tool parts
- Avoids thought signature validation errors with Gemini 3+ models

## Problem
Gemini 3+ models have strict validation requiring `thoughtSignature` on `functionCall` parts. When the plugin injects synthetic assistant messages with tool parts, providers without robust signature handling fail with 400 errors:

```
Function call is missing a thought_signature in functionCall parts.
```

## Solution
Check if the model is Gemini (via `modelID.includes("gemini")`) and inject the prunable tools list as a **text part** instead of a **tool part**. This avoids the thought signature requirement entirely while maintaining the same functionality.

| Model | Injection Type |
|-------|---------------|
| Gemini | Text part |
| All others | Tool part (unchanged) |