### PR TITLE
refactor: unify commands into single /dcp with subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,8 @@ DCP uses its own config file:
     "debug": false,
     // Notification display: "off", "minimal", or "detailed"
     "pruneNotification": "detailed",
-    // Enable or disable slash commands
-    "commands": {
-        "context": {
-            "enabled": true,
-        },
-        "stats": {
-            "enabled": true,
-        },
-    },
+    // Enable or disable slash commands (/dcp)
+    "commands": true,
     // Protect from pruning for <turns> message turns
     "turnProtection": {
         "enabled": false,
@@ -137,10 +130,11 @@ DCP uses its own config file:
 
 ### Commands
 
-DCP provides two slash commands for visibility into context usage:
+DCP provides a `/dcp` slash command:
 
-- `/dcp-context` — Shows a breakdown of your current session's token usage by category (system, user, assistant, tools, etc.) and how much has been saved through pruning.
-- `/dcp-stats` — Shows cumulative pruning statistics across all sessions.
+- `/dcp` — Shows available DCP commands
+- `/dcp context` — Shows a breakdown of your current session's token usage by category (system, user, assistant, tools, etc.) and how much has been saved through pruning.
+- `/dcp stats` — Shows cumulative pruning statistics across all sessions.
 
 ### Turn Protection
 

--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -27,35 +27,9 @@
             "description": "Level of notification shown when pruning occurs"
         },
         "commands": {
-            "type": "object",
-            "description": "Enable or disable slash commands",
-            "additionalProperties": false,
-            "properties": {
-                "context": {
-                    "type": "object",
-                    "description": "Configuration for /dcp-context command",
-                    "additionalProperties": false,
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "default": true,
-                            "description": "Enable the /dcp-context command"
-                        }
-                    }
-                },
-                "stats": {
-                    "type": "object",
-                    "description": "Configuration for /dcp-stats command",
-                    "additionalProperties": false,
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "default": true,
-                            "description": "Enable the /dcp-stats command"
-                        }
-                    }
-                }
-            }
+            "type": "boolean",
+            "default": true,
+            "description": "Enable DCP slash commands (/dcp)"
         },
         "turnProtection": {
             "type": "object",

--- a/index.ts
+++ b/index.ts
@@ -68,16 +68,13 @@ const plugin: Plugin = (async (ctx) => {
             }),
         },
         config: async (opencodeConfig) => {
-            opencodeConfig.command ??= {}
-            opencodeConfig.command["dcp-stats"] = {
-                template: "",
-                description: "Show DCP pruning statistics",
+            if (config.commands) {
+                opencodeConfig.command ??= {}
+                opencodeConfig.command["dcp"] = {
+                    template: "",
+                    description: "Show available DCP commands",
+                }
             }
-            opencodeConfig.command["dcp-context"] = {
-                template: "",
-                description: "Show token usage breakdown for current session",
-            }
-            logger.info("Registered /dcp-stats and /dcp-context commands")
 
             const toolsToAdd: string[] = []
             if (config.tools.discard.enabled) toolsToAdd.push("discard")

--- a/lib/commands/help.ts
+++ b/lib/commands/help.ts
@@ -1,0 +1,47 @@
+/**
+ * DCP Help command handler.
+ * Shows available DCP commands and their descriptions.
+ */
+
+import type { Logger } from "../logger"
+import type { SessionState, WithParts } from "../state"
+import { sendIgnoredMessage } from "../ui/notification"
+import { getCurrentParams } from "../strategies/utils"
+
+export interface HelpCommandContext {
+    client: any
+    state: SessionState
+    logger: Logger
+    sessionId: string
+    messages: WithParts[]
+}
+
+function formatHelpMessage(): string {
+    const lines: string[] = []
+
+    lines.push("╭───────────────────────────────────────────────────────────╮")
+    lines.push("│                      DCP Commands                         │")
+    lines.push("╰───────────────────────────────────────────────────────────╯")
+    lines.push("")
+    lines.push("Available commands:")
+    lines.push("  context  - Show token usage breakdown for current session")
+    lines.push("  stats    - Show DCP pruning statistics")
+    lines.push("")
+    lines.push("Examples:")
+    lines.push("  /dcp context")
+    lines.push("  /dcp stats")
+    lines.push("")
+
+    return lines.join("\n")
+}
+
+export async function handleHelpCommand(ctx: HelpCommandContext): Promise<void> {
+    const { client, state, logger, sessionId, messages } = ctx
+
+    const message = formatHelpMessage()
+
+    const params = getCurrentParams(state, messages, logger)
+    await sendIgnoredMessage(client, sessionId, message, params, logger)
+
+    logger.info("Help command executed")
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -45,20 +45,11 @@ export interface TurnProtection {
     turns: number
 }
 
-export interface CommandConfig {
-    enabled: boolean
-}
-
-export interface Commands {
-    context: CommandConfig
-    stats: CommandConfig
-}
-
 export interface PluginConfig {
     enabled: boolean
     debug: boolean
     pruneNotification: "off" | "minimal" | "detailed"
-    commands: Commands
+    commands: boolean
     turnProtection: TurnProtection
     protectedFilePatterns: string[]
     tools: Tools
@@ -95,10 +86,6 @@ export const VALID_CONFIG_KEYS = new Set([
     "turnProtection.turns",
     "protectedFilePatterns",
     "commands",
-    "commands.context",
-    "commands.context.enabled",
-    "commands.stats",
-    "commands.stats.enabled",
     "tools",
     "tools.settings",
     "tools.settings.nudgeEnabled",
@@ -211,26 +198,14 @@ function validateConfigTypes(config: Record<string, any>): ValidationError[] {
         }
     }
 
-    // Commands validators
+    // Commands validator
     const commands = config.commands
-    if (commands) {
-        if (
-            commands.context?.enabled !== undefined &&
-            typeof commands.context.enabled !== "boolean"
-        ) {
-            errors.push({
-                key: "commands.context.enabled",
-                expected: "boolean",
-                actual: typeof commands.context.enabled,
-            })
-        }
-        if (commands.stats?.enabled !== undefined && typeof commands.stats.enabled !== "boolean") {
-            errors.push({
-                key: "commands.stats.enabled",
-                expected: "boolean",
-                actual: typeof commands.stats.enabled,
-            })
-        }
+    if (commands !== undefined && typeof commands !== "boolean") {
+        errors.push({
+            key: "commands",
+            expected: "boolean",
+            actual: typeof commands,
+        })
     }
 
     // Tools validators
@@ -425,14 +400,7 @@ const defaultConfig: PluginConfig = {
     enabled: true,
     debug: false,
     pruneNotification: "detailed",
-    commands: {
-        context: {
-            enabled: true,
-        },
-        stats: {
-            enabled: true,
-        },
-    },
+    commands: true,
     turnProtection: {
         enabled: false,
         turns: 4,
@@ -543,15 +511,8 @@ function createDefaultConfig(): void {
   "debug": false,
   // Notification display: "off", "minimal", or "detailed"
   "pruneNotification": "detailed",
-  // Enable or disable slash commands
-  "commands": {
-    "context": {
-      "enabled": true
-    },
-    "stats": {
-      "enabled": true
-    }
-  },
+  // Enable or disable slash commands (/dcp)
+  "commands": true,
   // Protect from pruning for <turns> message turns
   "turnProtection": {
     "enabled": false,
@@ -695,25 +656,14 @@ function mergeCommands(
     base: PluginConfig["commands"],
     override?: Partial<PluginConfig["commands"]>,
 ): PluginConfig["commands"] {
-    if (!override) return base
-
-    return {
-        context: {
-            enabled: override.context?.enabled ?? base.context.enabled,
-        },
-        stats: {
-            enabled: override.stats?.enabled ?? base.stats.enabled,
-        },
-    }
+    if (override === undefined) return base
+    return override as boolean
 }
 
 function deepCloneConfig(config: PluginConfig): PluginConfig {
     return {
         ...config,
-        commands: {
-            context: { ...config.commands.context },
-            stats: { ...config.commands.stats },
-        },
+        commands: config.commands,
         turnProtection: { ...config.turnProtection },
         protectedFilePatterns: [...config.protectedFilePatterns],
         tools: {


### PR DESCRIPTION
## Summary

- Replaces `/dcp-stats` and `/dcp-context` with `/dcp stats` and `/dcp context`
- Simplifies commands config from `{ enabled: true }` to just `commands: true`
- Adds help screen shown when `/dcp` is run without arguments
- Makes argument parsing future-proof for commands with multiple args

## Commands

- `/dcp` — Shows available DCP commands
- `/dcp context` — Shows token usage breakdown
- `/dcp stats` — Shows pruning statistics