### PR TITLE
Remove context_info tool references from system prompts

### DIFF
--- a/lib/prompts/system/both.ts
+++ b/lib/prompts/system/both.ts
@@ -2,9 +2,7 @@ export const SYSTEM_PROMPT_BOTH = `<system-reminder>
 <instruction name=context_management_protocol policy_level=critical>
 
 ENVIRONMENT
-You are operating in a context-constrained environment and thus must proactively manage your context window using the \`discard\` and \`extract\` tools. The environment calls the \`context_info\` tool to provide an up-to-date <prunable-tools> list after each assistant turn. Use this information when deciding what to prune.
-
-IMPORTANT: The \`context_info\` tool is only available to the environment - you do not have access to it and must not attempt to call it.
+You are operating in a context-constrained environment and thus must proactively manage your context window using the \`discard\` and \`extract\` tools. The environment provides an up-to-date <prunable-tools> list after each assistant turn. Use this information when deciding what to prune.
 
 TWO TOOLS FOR CONTEXT MANAGEMENT
 - \`discard\`: Remove tool outputs that are no longer needed (completed tasks, noise, outdated info). No preservation of content.
@@ -44,7 +42,7 @@ There may be tools in session context that do not appear in the <prunable-tools>
 </instruction>
 
 <instruction name=injected_context_handling policy_level=critical>
-After each assistant turn, the environment calls the \`context_info\` tool to inject an assistant message containing a <prunable-tools> list and optional nudge instruction. This tool is only available to the environment - you do not have access to it.
+After each assistant turn, the environment injects an assistant message containing a <prunable-tools> list and optional nudge instruction.
 
 CRITICAL REQUIREMENTS - VIOLATION IS UNACCEPTABLE:
 - NEVER reference the prune encouragement or context management instructions. Do not reply with "I agree" or "Great idea" when the prune encouragement appears.

--- a/lib/prompts/system/discard.ts
+++ b/lib/prompts/system/discard.ts
@@ -2,9 +2,7 @@ export const SYSTEM_PROMPT_DISCARD = `<system-reminder>
 <instruction name=context_management_protocol policy_level=critical>
 
 ENVIRONMENT
-You are operating in a context-constrained environment and thus must proactively manage your context window using the \`discard\` tool. The environment calls the \`context_info\` tool to provide an up-to-date <prunable-tools> list after each assistant turn. Use this information when deciding what to discard.
-
-IMPORTANT: The \`context_info\` tool is only available to the environment - you do not have access to it and must not attempt to call it.
+You are operating in a context-constrained environment and thus must proactively manage your context window using the \`discard\` tool. The environment provides an up-to-date <prunable-tools> list after each assistant turn. Use this information when deciding what to discard.
 
 CONTEXT MANAGEMENT TOOL
 - \`discard\`: Remove tool outputs that are no longer needed (completed tasks, noise, outdated info). No preservation of content.
@@ -35,7 +33,7 @@ There may be tools in session context that do not appear in the <prunable-tools>
 </instruction>
 
 <instruction name=injected_context_handling policy_level=critical>
-After each assistant turn, the environment calls the \`context_info\` tool to inject an assistant message containing a <prunable-tools> list and optional nudge instruction. This tool is only available to the environment - you do not have access to it.
+After each assistant turn, the environment injects an assistant message containing a <prunable-tools> list and optional nudge instruction.
 
 CRITICAL REQUIREMENTS - VIOLATION IS UNACCEPTABLE:
 - NEVER reference the discard encouragement or context management instructions. Do not reply with "I agree" or "Great idea" when the discard encouragement appears.

--- a/lib/prompts/system/extract.ts
+++ b/lib/prompts/system/extract.ts
@@ -2,9 +2,7 @@ export const SYSTEM_PROMPT_EXTRACT = `<system-reminder>
 <instruction name=context_management_protocol policy_level=critical>
 
 ENVIRONMENT
-You are operating in a context-constrained environment and thus must proactively manage your context window using the \`extract\` tool. The environment calls the \`context_info\` tool to provide an up-to-date <prunable-tools> list after each assistant turn. Use this information when deciding what to extract.
-
-IMPORTANT: The \`context_info\` tool is only available to the environment - you do not have access to it and must not attempt to call it.
+You are operating in a context-constrained environment and thus must proactively manage your context window using the \`extract\` tool. The environment provides an up-to-date <prunable-tools> list after each assistant turn. Use this information when deciding what to extract.
 
 CONTEXT MANAGEMENT TOOL
 - \`extract\`: Extract key findings from tools into distilled knowledge before removing the raw content from context. Use this to preserve important information while reducing context size.
@@ -35,7 +33,7 @@ There may be tools in session context that do not appear in the <prunable-tools>
 </instruction>
 
 <instruction name=injected_context_handling policy_level=critical>
-After each assistant turn, the environment calls the \`context_info\` tool to inject an assistant message containing a <prunable-tools> list and optional nudge instruction. This tool is only available to the environment - you do not have access to it.
+After each assistant turn, the environment injects an assistant message containing a <prunable-tools> list and optional nudge instruction.
 
 CRITICAL REQUIREMENTS - VIOLATION IS UNACCEPTABLE:
 - NEVER reference the extract encouragement or context management instructions. Do not reply with "I agree" or "Great idea" when the extract encouragement appears.


### PR DESCRIPTION
The mentions of context_info tool were confusing LLMs into thinking they had access to this tool and attempting to call it. The information about prunable tools is now described as simply "provided by the environment" without mentioning the internal tool name.

Even with smart models like Opus 4.5 Thinking or GPT 5.2 High agents were hallucinating that tool mulitple times per session