### PR TITLE
feat(experimental): add DCP support for sub-agents

### DIFF
--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -207,6 +207,129 @@
                     }
                 }
             }
+        },
+        "experimental": {
+            "type": "object",
+            "description": "Experimental features (may change or be removed in future versions)",
+            "additionalProperties": false,
+            "properties": {
+                "subAgents": {
+                    "type": "object",
+                    "description": "Enable DCP for specific sub-agents (experimental)",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Enable DCP for sub-agents matching the configured patterns"
+                        },
+                        "agents": {
+                            "type": "array",
+                            "description": "List of sub-agent configurations",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": ["name", "systemPromptPatterns", "config"],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Unique identifier for this sub-agent configuration"
+                                    },
+                                    "systemPromptPatterns": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "Patterns to match in the system prompt to identify this sub-agent type (substring matching)"
+                                    },
+                                    "config": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "required": ["prunableTools"],
+                                        "properties": {
+                                            "prunableTools": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "description": "Tools that can be pruned for this sub-agent type"
+                                            },
+                                            "strategies": {
+                                                "type": "object",
+                                                "description": "Override strategies for this sub-agent",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "deduplication": {
+                                                        "type": "object",
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "enabled": {
+                                                                "type": "boolean",
+                                                                "description": "Enable deduplication for this sub-agent"
+                                                            }
+                                                        }
+                                                    },
+                                                    "supersedeWrites": {
+                                                        "type": "object",
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "enabled": {
+                                                                "type": "boolean",
+                                                                "description": "Enable supersede writes for this sub-agent"
+                                                            }
+                                                        }
+                                                    },
+                                                    "purgeErrors": {
+                                                        "type": "object",
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "enabled": {
+                                                                "type": "boolean",
+                                                                "description": "Enable purge errors for this sub-agent"
+                                                            },
+                                                            "turns": {
+                                                                "type": "number",
+                                                                "description": "Number of turns before errors are purged"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "tools": {
+                                                "type": "object",
+                                                "description": "Override tool settings for this sub-agent",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "discard": {
+                                                        "type": "object",
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "enabled": {
+                                                                "type": "boolean",
+                                                                "description": "Enable discard tool for this sub-agent"
+                                                            }
+                                                        }
+                                                    },
+                                                    "extract": {
+                                                        "type": "object",
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "enabled": {
+                                                                "type": "boolean",
+                                                                "description": "Enable extract tool for this sub-agent"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -22,8 +22,15 @@ export function createSystemPromptHandler(
     config: PluginConfig,
 ) {
     return async (_input: unknown, output: { system: string[] }) => {
+        // For sub-agents, check if DCP is enabled via experimental config
         if (state.isSubAgent) {
-            return
+            if (!state.subAgentState.dcpEnabled) {
+                logger.info("Skipping DCP system prompt for sub-agent (not enabled in config)")
+                return
+            }
+            logger.info("Sub-agent DCP enabled, injecting system prompt", {
+                matchedAgent: state.subAgentState.matchedConfig?.name,
+            })
         }
 
         const systemText = output.system.join("\n")
@@ -32,8 +39,20 @@ export function createSystemPromptHandler(
             return
         }
 
-        const discardEnabled = config.tools.discard.enabled
-        const extractEnabled = config.tools.extract.enabled
+        // Determine which tools are enabled for this session
+        let discardEnabled = config.tools.discard.enabled
+        let extractEnabled = config.tools.extract.enabled
+
+        // For sub-agents, check if tools are overridden in the config
+        if (state.isSubAgent && state.subAgentState.matchedConfig?.config.tools) {
+            const toolsOverride = state.subAgentState.matchedConfig.config.tools
+            if (toolsOverride.discard?.enabled !== undefined) {
+                discardEnabled = toolsOverride.discard.enabled
+            }
+            if (toolsOverride.extract?.enabled !== undefined) {
+                extractEnabled = toolsOverride.extract.enabled
+            }
+        }
 
         let promptName: string
         if (discardEnabled && extractEnabled) {
@@ -58,26 +77,89 @@ export function createChatMessageTransformHandler(
     config: PluginConfig,
 ) {
     return async (input: {}, output: { messages: WithParts[] }) => {
-        await checkSession(client, state, logger, output.messages)
+        await checkSession(client, state, logger, config, output.messages)
 
-        if (state.isSubAgent) {
+        // For sub-agents, check if DCP is enabled via experimental config
+        if (state.isSubAgent && !state.subAgentState.dcpEnabled) {
+            logger.debug("Skipping DCP for sub-agent (not enabled in config)")
             return
         }
 
-        syncToolCache(state, config, logger, output.messages)
+        // Get effective config for this session (may have sub-agent overrides)
+        const effectiveConfig = getEffectiveConfig(config, state)
 
-        deduplicate(state, logger, config, output.messages)
-        supersedeWrites(state, logger, config, output.messages)
-        purgeErrors(state, logger, config, output.messages)
+        syncToolCache(state, effectiveConfig, logger, output.messages)
 
-        prune(state, logger, config, output.messages)
+        deduplicate(state, logger, effectiveConfig, output.messages)
+        supersedeWrites(state, logger, effectiveConfig, output.messages)
+        purgeErrors(state, logger, effectiveConfig, output.messages)
 
-        insertPruneToolContext(state, config, logger, output.messages)
+        prune(state, logger, effectiveConfig, output.messages)
+
+        insertPruneToolContext(state, effectiveConfig, logger, output.messages)
 
         if (state.sessionId) {
             await logger.saveContext(state.sessionId, output.messages)
         }
     }
+}
+
+// Get effective config with sub-agent overrides applied
+function getEffectiveConfig(config: PluginConfig, state: SessionState): PluginConfig {
+    if (!state.isSubAgent || !state.subAgentState.matchedConfig) {
+        return config
+    }
+
+    const agentConfig = state.subAgentState.matchedConfig.config
+
+    // Create a copy of the config with sub-agent overrides
+    const effectiveConfig: PluginConfig = {
+        ...config,
+        tools: {
+            ...config.tools,
+            settings: {
+                ...config.tools.settings,
+                // For sub-agents, only the tools defined in prunableTools should be prunable
+                // All other tools should be protected
+                protectedTools: [
+                    ...config.tools.settings.protectedTools,
+                ],
+            },
+            discard: {
+                ...config.tools.discard,
+                ...(agentConfig.tools?.discard || {}),
+            },
+            extract: {
+                ...config.tools.extract,
+                ...(agentConfig.tools?.extract || {}),
+            },
+        },
+        strategies: {
+            deduplication: {
+                ...config.strategies.deduplication,
+                enabled:
+                    agentConfig.strategies?.deduplication?.enabled ??
+                    config.strategies.deduplication.enabled,
+            },
+            supersedeWrites: {
+                ...config.strategies.supersedeWrites,
+                enabled:
+                    agentConfig.strategies?.supersedeWrites?.enabled ??
+                    config.strategies.supersedeWrites.enabled,
+            },
+            purgeErrors: {
+                ...config.strategies.purgeErrors,
+                enabled:
+                    agentConfig.strategies?.purgeErrors?.enabled ??
+                    config.strategies.purgeErrors.enabled,
+                turns:
+                    agentConfig.strategies?.purgeErrors?.turns ??
+                    config.strategies.purgeErrors.turns,
+            },
+        },
+    }
+
+    return effectiveConfig
 }
 
 export function createCommandExecuteHandler(

--- a/lib/state/types.ts
+++ b/lib/state/types.ts
@@ -1,4 +1,5 @@
 import { Message, Part } from "@opencode-ai/sdk/v2"
+import type { SubAgentEntry } from "../config"
 
 export interface WithParts {
     info: Message
@@ -24,9 +25,21 @@ export interface Prune {
     toolIds: string[]
 }
 
+// Sub-agent state information
+export interface SubAgentState {
+    // Whether DCP is enabled for this sub-agent (based on config matching)
+    dcpEnabled: boolean
+    // The matched sub-agent configuration (if any)
+    matchedConfig: SubAgentEntry | null
+    // The system prompt used for matching (cached for debugging)
+    systemPrompt: string | null
+}
+
 export interface SessionState {
     sessionId: string | null
     isSubAgent: boolean
+    // Sub-agent specific DCP state (experimental)
+    subAgentState: SubAgentState
     prune: Prune
     stats: SessionStats
     toolParameters: Map<string, ToolParameterEntry>

--- a/lib/state/utils.ts
+++ b/lib/state/utils.ts
@@ -1,8 +1,40 @@
+export interface SubAgentSessionInfo {
+    isSubAgent: boolean
+    parentID: string | null
+    systemPrompt: string | null
+}
+
 export async function isSubAgentSession(client: any, sessionID: string): Promise<boolean> {
     try {
         const result = await client.session.get({ path: { id: sessionID } })
         return !!result.data?.parentID
     } catch (error: any) {
         return false
+    }
+}
+
+export async function getSubAgentSessionInfo(
+    client: any,
+    sessionID: string,
+): Promise<SubAgentSessionInfo> {
+    try {
+        const result = await client.session.get({ path: { id: sessionID } })
+        const isSubAgent = !!result.data?.parentID
+        const parentID = result.data?.parentID || null
+
+        // Get system prompt from session if available
+        let systemPrompt: string | null = null
+        if (isSubAgent && result.data?.system) {
+            // system can be a string or array of strings
+            if (Array.isArray(result.data.system)) {
+                systemPrompt = result.data.system.join("\n")
+            } else if (typeof result.data.system === "string") {
+                systemPrompt = result.data.system
+            }
+        }
+
+        return { isSubAgent, parentID, systemPrompt }
+    } catch (error: any) {
+        return { isSubAgent: false, parentID: null, systemPrompt: null }
     }
 }

--- a/lib/strategies/tools.ts
+++ b/lib/strategies/tools.ts
@@ -59,7 +59,7 @@ async function executePruneOperation(
     })
     const messages: WithParts[] = messagesResponse.data || messagesResponse
 
-    await ensureSessionInitialized(ctx.client, state, sessionId, logger, messages)
+    await ensureSessionInitialized(ctx.client, state, sessionId, logger, config, messages)
 
     const currentParams = getCurrentParams(state, messages, logger)
     const toolIdList: string[] = buildToolIdList(state, messages, logger)


### PR DESCRIPTION
Add experimental configuration to enable DCP for specific sub-agents based on system prompt pattern matching.

Key changes:
- Add experimental.subAgents configuration section
- Allow per-sub-agent configuration of prunable tools
- Support strategy and tool overrides per sub-agent
- Detect sub-agent type from system prompt patterns
- Apply DCP only when enabled and patterns match

This feature allows users to selectively enable context pruning for long-running sub-agents that would benefit from reduced context size.

Code not tried yet but DCP for sub agents would be a really useful features, sometimes we don't really care if the sub agent resume is perfect and we need the precious extra context DCP offers. Can be disabled by default but should be something configurable, even if experimental with warning.