### PR TITLE
feat: show extracted token count in prune notifications

### DIFF
--- a/lib/ui/utils.ts
+++ b/lib/ui/utils.ts
@@ -1,5 +1,11 @@
 import { ToolParameterEntry } from "../state"
 import { extractParameterKey } from "../messages/utils"
+import { countTokens } from "../strategies/utils"
+
+export function countDistillationTokens(distillation?: string[]): number {
+    if (!distillation || distillation.length === 0) return 0
+    return countTokens(distillation.join("\n"))
+}
 
 export function formatExtracted(distillation?: string[]): string {
     if (!distillation || distillation.length === 0) {


### PR DESCRIPTION
## Summary

- Add token count display for extractions in prune notifications (e.g., `extracted 85 tokens`)
- Token count always appears when distillation is present, in both minimal and detailed formats