### PR TITLE
fix: add secure mode authentication support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ import {
     createCommandExecuteHandler,
     createSystemPromptHandler,
 } from "./lib/hooks"
+import { configureClientAuth, isSecureMode } from "./lib/auth"
 
 const plugin: Plugin = (async (ctx) => {
     const config = getConfig(ctx)
@@ -18,6 +19,11 @@ const plugin: Plugin = (async (ctx) => {
 
     const logger = new Logger(config.debug)
     const state = createSessionState()
+
+    if (isSecureMode()) {
+        configureClientAuth(ctx.client)
+        // logger.info("Secure mode detected, configured client authentication")
+    }
 
     logger.info("DCP initialized", {
         strategies: config.strategies,

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,37 @@
+export function isSecureMode(): boolean {
+    return !!process.env.OPENCODE_SERVER_PASSWORD
+}
+
+export function getAuthorizationHeader(): string | undefined {
+    const password = process.env.OPENCODE_SERVER_PASSWORD
+    if (!password) return undefined
+
+    const username = process.env.OPENCODE_SERVER_USERNAME ?? "opencode"
+    // Use Buffer for Node.js base64 encoding (btoa may not be available in all Node versions)
+    const credentials = Buffer.from(`${username}:${password}`).toString("base64")
+    return `Basic ${credentials}`
+}
+
+export function configureClientAuth(client: any): any {
+    const authHeader = getAuthorizationHeader()
+
+    if (!authHeader) {
+        return client
+    }
+
+    // The SDK client has an internal client with request interceptors
+    // Access the underlying client to add the interceptor
+    const innerClient = client._client || client.client
+
+    if (innerClient?.interceptors?.request) {
+        innerClient.interceptors.request.use((request: Request) => {
+            // Only add auth header if not already present
+            if (!request.headers.has("Authorization")) {
+                request.headers.set("Authorization", authHeader)
+            }
+            return request
+        })
+    }
+
+    return client
+}


### PR DESCRIPTION
Adds `lib/auth.ts` with utilities to detect secure mode and configure client authentication
When `OPENCODE_SERVER_PASSWORD` is set, injects HTTP Basic Auth headers on all SDK client requests
Uses request interceptors to transparently add auth without modifying existing code

Fixes #304 `TypeError: {} is not iterable`, desktop rendering still broken and causes app to crash but web app and other clients that use secure mode should work now