### PR TITLE
feat: auto-disable DCP on Desktop clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Using `@latest` ensures you always get the newest version automatically when Ope
 
 Restart OpenCode. The plugin will automatically start optimizing your sessions.
 
+> **Important:** DCP is designed for the TUI (terminal) version of OpenCode. It auto-disables on Desktop/Web clients (see [Known Issues](#known-issues)).
+
 ## How Pruning Works
 
 DCP uses multiple tools and strategies to reduce context size:
@@ -146,6 +148,25 @@ DCP provides a `/dcp` slash command:
 When enabled, turn protection prevents tool outputs from being pruned for a configurable number of message turns. This gives the AI time to reference recent tool outputs before they become prunable. Applies to both `discard` and `extract` tools, as well as automatic strategies.
 
 ### Protected Tools
+
+## Known Issues
+
+### Desktop / Web App Incompatibility
+
+DCP is currently incompatible with OpenCode's desktop and web clients. This is a known issue tracked in [Issue #304](https://github.com/Opencode-DCP/opencode-dynamic-context-pruning/issues/304).
+
+**Symptoms on Desktop/Web:**
+
+- `/dcp` commands fail with `TypeError: {} is not iterable`
+- `discard` and `extract` tools fail with the same error
+- Pruning notifications don't display correctly
+
+**Solution:**
+
+- DCP automatically detects when running on Desktop (Electron-based clients) and **auto-disables itself** with a console message
+- Use the TUI version of OpenCode for full DCP functionality
+
+**Status:** The plugin is designed for TUI usage only. Desktop/Web clients have breaking changes in their `@opencode-ai/plugin` implementation that haven't been addressed yet.
 
 By default, these tools are always protected from pruning across all strategies:
 `task`, `todowrite`, `todoread`, `discard`, `extract`, `batch`, `write`, `edit`

--- a/index.ts
+++ b/index.ts
@@ -9,10 +9,21 @@ import {
     createSystemPromptHandler,
 } from "./lib/hooks"
 
+function isDesktop(): boolean {
+    return process.env.ELECTRON_RUN_AS_NODE !== undefined
+}
+
 const plugin: Plugin = (async (ctx) => {
     const config = getConfig(ctx)
 
     if (!config.enabled) {
+        return {}
+    }
+
+    if (isDesktop()) {
+        console.log(
+            "DCP: Auto-disabled on Desktop – use the TUI version for full DCP functionality",
+        )
         return {}
     }
 


### PR DESCRIPTION
# Summary
DCP is currently incompatible with Desktop/Web OpenCode clients (issue #304). This PR adds automatic detection of Electron/Desktop environments and auto-disables the plugin with a clear console message.

# Changes

- **index.ts**: Added `isDesktop()` function that checks for `ELECTRON_RUN_AS_NODE` environment variable (set by Electron-based clients)
  - Auto-disables DCP when running on Desktop
  - Logs a console message explaining why
- **README.md**: 
  - Added note about TUI-only support in Installation section
  - Added "Known Issues" section documenting the Desktop incompatibility

# Testing
Tested on:
- ✅ TUI version: DCP works normally
- ✅ Desktop version: DCP auto-disables and logs message

# Context
I've found DCP works significantly better in TUI than Desktop - the Desktop client has breaking changes in `@opencode-ai/plugin` that weren't handled, leading to errors like `TypeError: {} is not iterable` for `/dcp` commands and the `discard`/`extract` tools.

This is a temporary workaround/plugin boundary solution while the deeper compatibility issues with newer OpenCode versions get resolved. The auto-disable approach keeps DCP functional for TUI users while preventing confusing errors for Desktop users.