### PR TITLE
feat: auto-disable DCP on Desktop clients (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ LLM providers like Anthropic and OpenAI cache prompts based on exact prefix matc
 
 **Best use case:** Providers that count usage in requests, such as Github Copilot and Google Antigravity have no negative price impact.
 
+> **Important:** DCP is designed for the TUI (terminal) version of OpenCode. It auto-disables on Desktop/Web clients (see [Known Issues](#known-issues)).
+
 ## Configuration
 
 DCP uses its own config file:
@@ -159,6 +161,25 @@ Defaults → Global (`~/.config/opencode/dcp.jsonc`) → Config Dir (`$OPENCODE_
 Each level overrides the previous, so project settings take priority over config-dir and global, which take priority over defaults.
 
 Restart OpenCode after making config changes.
+
+## Known Issues
+
+### Desktop / Web App Incompatibility
+
+DCP is currently incompatible with OpenCode's desktop and web clients. This is a known issue tracked in [Issue #304](https://github.com/Opencode-DCP/opencode-dynamic-context-pruning/issues/304).
+
+**Symptoms on Desktop/Web:**
+
+- `/dcp` commands fail with errors
+- `discard` and `extract` tools fail
+- Pruning notifications don't display correctly
+
+**Solution:**
+
+- DCP automatically detects when running on Desktop/Web and auto-disables itself with a console message
+- Use the TUI version of OpenCode for full DCP functionality
+
+**Status:** The plugin is designed for TUI usage only. Desktop/Web clients have breaking changes in their `@opencode-ai/plugin` implementation that haven't been addressed yet.
 
 ## Limitations
 

--- a/index.ts
+++ b/index.ts
@@ -9,10 +9,24 @@ import {
     createSystemPromptHandler,
 } from "./lib/hooks"
 
+function isDesktop(): boolean {
+    // Check if running in serve mode (Desktop) vs tui/worker (TUI)
+    // Desktop: ["bun","/$bunfs/root/src/index.js","serve",...]
+    // TUI: ["bun","/$bunfs/root/src/cli/cmd/tui/worker.js"]
+    return process.argv.includes("serve")
+}
+
 const plugin: Plugin = (async (ctx) => {
     const config = getConfig(ctx)
 
     if (!config.enabled) {
+        return {}
+    }
+
+    if (isDesktop()) {
+        console.log(
+            "DCP: Auto-disabled on Desktop – use the TUI version for full DCP functionality",
+        )
         return {}
     }
 


### PR DESCRIPTION
# Summary
DCP seems incompatible with Desktop/Web OpenCode clients due to breaking changes in `@opencode-ai/plugin`. This PR adds automatic detection of Desktop environment and auto-disables the plugin.

# Changes

- **index.ts**: Added `isDesktop()` function that detects Desktop vs TUI via `process.argv`
  - Desktop: `process.argv` contains `"serve"` command
  - TUI: `process.argv` contains `"tui/worker"` path
  - Plugin runs on server side, NOT client side
  - Auto-disables DCP when running in Desktop mode
- **README.md**: 
  - Added note about TUI-only support in Installation section
  - Added "Known Issues" section documenting the Desktop incompatibility

# Technical Details
After debugging and testing, discovered that Desktop vs TUI is distinguished by the command line, it is not pretty but it works:

**Desktop mode:**
```
process.argv: ["bun","/$bunfs/root/src/index.js","serve","--hostname","127.0.0.1","--port","54752"]
```

**TUI mode:**
```
process.argv: ["bun","/$bunfs/root/src/cli/cmd/tui/worker.js"]
```

# Testing

Tested on both environments:

## Desktop (MacOS)
```
[DCP] Plugin starting...
[DCP] isDesktop(): true
[DCP] Desktop detected, disabling DCP
DCP: Auto-disabled on Desktop – use the TUI version for full DCP functionality
```
Result: `/dcp` commands NOT available (plugin auto-disabled)

## TUI (MacOS)
```
[DCP] Plugin starting...
[DCP] isDesktop(): false
[DCP] Not desktop, continuing with full plugin
```
Result: `/dcp` commands work normally (plugin fully functional)