### PR TITLE
v1.2.8 - Version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tarquinen/opencode-dcp",
-    "version": "1.2.7",
+    "version": "1.2.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tarquinen/opencode-dcp",
-            "version": "1.2.7",
+            "version": "1.2.8",
             "license": "MIT",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "@tarquinen/opencode-dcp",
-    "version": "1.2.7",
+    "version": "1.2.8",
     "type": "module",
     "description": "OpenCode plugin that optimizes token usage by pruning obsolete tool outputs from conversation context",
     "main": "./dist/index.js",


### PR DESCRIPTION
Bump version to 1.2.8 for release.

## Changes since v1.2.7
- refactor: hybrid injection strategy for DeepSeek/Kimi models
- feat: default to empty protectedTools for deduplication and purgeErrors strategies
- docs: add Ko-fi sponsorship link