### PR TITLE
feat: add percentage support for contextLimit configuration

### DIFF
--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -110,7 +110,7 @@
                             "description": "Tool names that should be protected from automatic pruning"
                         },
                         "contextLimit": {
-                            "description": "When session tokens exceed this limit, a compress nudge is injected (\"model\" uses the active model's context limit)",
+                            "description": "When session tokens exceed this limit, a compress nudge is injected (\"model\" uses the active model's context limit, \"X%\" uses percentage of the model's context window)",
                             "default": 100000,
                             "oneOf": [
                                 {
@@ -119,6 +119,10 @@
                                 {
                                     "type": "string",
                                     "enum": ["model"]
+                                },
+                                {
+                                    "type": "string",
+                                    "pattern": "^\\d+(?:\\.\\d+)?%$"
                                 }
                             ]
                         }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -27,7 +27,7 @@ export interface ToolSettings {
     nudgeEnabled: boolean
     nudgeFrequency: number
     protectedTools: string[]
-    contextLimit: number | "model"
+    contextLimit: number | "model" | `${number}%`
 }
 
 export interface Tools {
@@ -290,13 +290,16 @@ function validateConfigTypes(config: Record<string, any>): ValidationError[] {
                 })
             }
             if (tools.settings.contextLimit !== undefined) {
-                if (
-                    typeof tools.settings.contextLimit !== "number" &&
-                    tools.settings.contextLimit !== "model"
-                ) {
+                const isValidNumber = typeof tools.settings.contextLimit === "number"
+                const isModelString = tools.settings.contextLimit === "model"
+                const isPercentString =
+                    typeof tools.settings.contextLimit === "string" &&
+                    tools.settings.contextLimit.endsWith("%")
+
+                if (!isValidNumber && !isModelString && !isPercentString) {
                     errors.push({
                         key: "tools.settings.contextLimit",
-                        expected: 'number | "model"',
+                        expected: 'number | "model" | "${number}%"',
                         actual: JSON.stringify(tools.settings.contextLimit),
                     })
                 }


### PR DESCRIPTION
### summary
Allow contextLimit to accept percentage strings (e.g. "40%") to specify a percentage of the model's context window instead of fixed values.

Values are rounded and clamped between 0 and 100.

### examples
- "40%" → 40% of model context window
- "40.7%" → rounded to 41%
- "-5%" → clamped to 0%
- "999%" → clamped to 100%