### PR TITLE
feat: add model-specific context limits via modelLimits

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ DCP uses its own config file:
 >             // to keep the model in the "smart zone" (not a hard limit)
 >             // Accepts: number or "X%" (percentage of model's context window)
 >             "contextLimit": 100000,
+>             // Optional per-model overrides by exact providerID/modelID
+>             // Accepts: number or "X%"
+>             // Example:
+>             // "modelLimits": {
+>             //     "openai/gpt-5": 120000,
+>             //     "anthropic/claude-3-7-sonnet": "80%"
+>             // },
 >             // Additional tools to protect from pruning
 >             "protectedTools": [],
 >         },

--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -123,7 +123,7 @@
                             ]
                         },
                         "modelLimits": {
-                            "description": "Model-specific context limits with optional wildcard patterns (exact match first, then most specific wildcard). Examples: \"openai/gpt-5\", \"*/zen-1\", \"ollama/*\", \"*sonnet*\"",
+                            "description": "Model-specific context limits by exact provider/model key. Examples: \"openai/gpt-5\", \"anthropic/claude-3-7-sonnet\", \"ollama/llama3.1\"",
                             "type": "object",
                             "additionalProperties": {
                                 "oneOf": [


### PR DESCRIPTION
### summary
Introduce toolSettings.modelLimits to allow per-model context limits as absolute token values or percentages (`contextLimit` or hardcoded value is fallback).

### example
```json
{
  "toolSettings": {
    "contextLimit": "60%",
    "modelLimits": {
      "opencode/dax-1": "40%",
      "opencode/zen-3": 120000
    }
  }
}
```