### PR TITLE
fix: concatenate system prompt to system[0] instead of push() to preserve agent prompts

### DIFF
--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -92,7 +92,15 @@ export function createSystemPromptHandler(
             return
         }
 
-        output.system.push(renderSystemPrompt(flags))
+        // Concatenate to system[0] instead of push() to avoid creating
+        // multiple {role: "system"} messages. OpenCode maps each system[]
+        // element to a separate system message, and providers typically
+        // only respect the last one — which drops the agent prompt.
+        if (output.system.length > 0) {
+            output.system[0] += "\n\n" + renderSystemPrompt(flags)
+        } else {
+            output.system.push(renderSystemPrompt(flags))
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

When using custom OpenCode agents (defined in `~/.config/opencode/agents/`), the agent's system prompt is lost when DCP is enabled.

**Root cause:** `createSystemPromptHandler` in `hooks.ts` line 95 does `output.system.push(renderSystemPrompt(flags))`, creating a second element in the `system[]` array.

OpenCode maps each `system[]` element to a separate `{role: "system"}` message:

```js
messages: [
  ...system.map((x) => ({ role: "system", content: x })),
  ...input.messages
]
```

Providers typically only respect one system message — the agent prompt in `system[0]` gets dropped.

## Isolated A/B Test

| hooks.ts | Result |
|---|---|
| `output.system.push(dcpPrompt)` (original) | ❌ Agent prompt missing |
| `output.system[0] += "\n\n" + dcpPrompt` (fix) | ✅ Agent prompt works |

The test was performed with `inject.js` in both original and patched states — only the `hooks.ts` change affected the outcome.

## Fix

Concatenate DCP prompt to `system[0]` instead of pushing a new element. Falls back to `push()` if `system[]` is empty (defensive).

```ts
if (output.system.length > 0) {
    output.system[0] += "\n\n" + renderSystemPrompt(flags)
} else {
    output.system.push(renderSystemPrompt(flags))
}
```

## Reproduction

1. Create a custom agent in `~/.config/opencode/agents/myagent.md`
2. Enable DCP plugin
3. Start a session with the custom agent
4. Observe: agent prompt is not delivered to the model