### PR TITLE
fix: preserve subsumed compress summaries

### DIFF
--- a/lib/prompts/compress.md
+++ b/lib/prompts/compress.md
@@ -31,6 +31,28 @@ USER INTENT FIDELITY
 When the compressed range includes user messages, preserve the user's intent with extra care. Do not change scope, constraints, priorities, acceptance criteria, or requested outcomes.
 Directly quote user messages when they are short enough to include safely. Direct quotes are preferred when they best preserve exact meaning.
 
+SUMMARY TAG MERGE PROTOCOL
+When the range you are compressing includes previously-compressed summaries, you MUST preserve them by using summary tags in your new `summary` text.
+
+- Use placeholders like `{summary_0}`, `{summary_1}`, `{summary_2}` where prior summaries should be injected.
+- Placeholder matching is case-insensitive (`{sumMary_0}` is treated the same as `{summary_0}`).
+- Tags map to the existing `<compress_result name="summary_N">` labels present in inherited summaries.
+- If there are multiple prior summaries, reference each one exactly once unless duplication is truly necessary.
+- Integrate tags naturally into your narrative so inherited context lands in the right section, not just as a generic preface.
+
+Example pattern inside your `summary`:
+
+```
+## Prior context
+{summary_0}
+
+## Recent work
+...
+
+## Additional inherited details
+{summary_1}
+```
+
 Yet be LEAN. Strip away the noise: failed attempts that led nowhere, verbose tool outputs, back-and-forth exploration. What remains should be pure signal - golden nuggets of detail that preserve full understanding with zero ambiguity.
 
 THE WAYS OF COMPRESS

--- a/lib/prompts/nudge.md
+++ b/lib/prompts/nudge.md
@@ -8,6 +8,8 @@ You should prioritize context management, but do not interrupt a critical atomic
 IMMEDIATE ACTION REQUIRED
 KNOWLEDGE PRESERVATION: If holding valuable raw data you POTENTIALLY will need in your task, compress the smallest closed range that preserves those findings. Write a high-fidelity summary so no key technical insight is lost.
 
+If the selected range includes previously-compressed summaries, place `{summary_0}`, `{summary_1}`, ... in your new summary where inherited context should be injected. Matching is case-insensitive and maps to inherited `<compress_result name="summary_N">` labels.
+
 NOISE REMOVAL: If you read files or ran commands that yielded no value, compress those dead-end ranges into explicit noise summaries and move on.
 
 PHASE COMPLETION: If a chapter is complete, compress the entire sequence into a detailed technical summary with unambiguous outcomes.
@@ -40,4 +42,6 @@ NEVER use tool input schema keys or field names. The ONLY acceptable use of tool
 
 Ensure your summaries are inclusive of all parts of the range.
 If the compressed range includes user messages, preserve user intent exactly. Prefer direct quotes for short user messages to avoid semantic drift.
+
+When the range includes prior compressed summaries, reference them with `{summary_0}`, `{summary_1}`, ... in the new summary so inherited details are injected at the right location (case-insensitive matching).
 </instruction>

--- a/lib/prompts/system.md
+++ b/lib/prompts/system.md
@@ -36,6 +36,14 @@ DO NOT USE A TOOL SCHEMA FIELD FOR START OR END STRING.
 THE SUMMARY STANDARD
 Your summary MUST be technical and specific enough to preserve FULL understanding of what transpired, such that NO ambiguity remains about what asked, found, planned, done, or decided - yet noise free
 
+SUMMARY TAG MERGE PROTOCOL
+When compressing a range that includes previously-compressed summaries, preserve them by placing summary tags in your new summary text:
+
+- Use `{summary_0}`, `{summary_1}`, `{summary_2}`, ... at the exact points where inherited summaries should appear.
+- Matching is case-insensitive (`{sumMary_0}` and `{summary_0}` are equivalent).
+- Tags map to inherited `<compress_result name="summary_N">` labels already present in context.
+- Prefer integrating each tag once into the right section rather than dumping inherited summaries as an undifferentiated block.
+
 When compressing ranges that include user messages, preserve user intent faithfully. Do not reinterpret or redirect the request. Directly quote short user messages when that is the most reliable way to preserve exact meaning.
 
 Preserve key details: file paths, symbols, signatures, constraints, decisions, outcomes, commands, etc.. in order to produce a high fidelity, authoritative technical record
@@ -52,7 +60,8 @@ It is of your responsibility to keep a sharp, high-quality context window for op
 </instruction>
 
 <manual><instruction name=manual_mode policy_level=critical>
-Manual mode is enabled. Do NOT use compress unless the user has explicitly triggered it through a manual marker.
+MANUAL MODE IS CURRENTLY ENABLED
+Do NOT use compress unless the user has explicitly triggered it through a manual marker.
 
 Only use the compress tool after seeing `<compress triggered manually>` in the current user instruction context.
 

--- a/tests/compress-summary-merge.test.ts
+++ b/tests/compress-summary-merge.test.ts
@@ -4,13 +4,21 @@ import { mergeSubsumedSummaries } from "../lib/tools/compress"
 import type { CompressSummary } from "../lib/state"
 
 const PREFIX = "[Compressed conversation block]\n\n"
+const WRAP = (name: string, content: string) =>
+    `<compress_result name="${name}">\n${content}\n</compress_result>`
+const APPEND_NOTICE = (currentSummaryName: string, count: number) => {
+    if (count === 1) {
+        return `${currentSummaryName} overlapped 1 summary that was not included in the output. It has been appended below:`
+    }
+    return `${currentSummaryName} overlapped ${count} summaries that were not included in the output. They have been appended below:`
+}
 
 test("mergeSubsumedSummaries keeps new summary when there are no prior summaries", () => {
-    const merged = mergeSubsumedSummaries([], "Newest summary")
+    const merged = mergeSubsumedSummaries([], "Newest summary", "summary_10")
     assert.equal(merged, "Newest summary")
 })
 
-test("mergeSubsumedSummaries prepends subsumed summaries in order", () => {
+test("mergeSubsumedSummaries injects summaries by numeric tag", () => {
     const removed: CompressSummary[] = [
         {
             anchorMessageId: "a1",
@@ -22,12 +30,96 @@ test("mergeSubsumedSummaries prepends subsumed summaries in order", () => {
         },
     ]
 
-    const merged = mergeSubsumedSummaries(removed, "Newest summary")
+    const merged = mergeSubsumedSummaries(
+        removed,
+        "Top\n{summary_0}\nMiddle\n{summary_1}\nBottom",
+        "summary_11",
+    )
 
-    assert.equal(merged, "Older summary A\n\nOlder summary B\n\nNewest summary")
+    assert.equal(
+        merged,
+        `Top\n${WRAP("summary_0", "Older summary A")}\nMiddle\n${WRAP("summary_1", "Older summary B")}\nBottom`,
+    )
 })
 
-test("mergeSubsumedSummaries ignores empty subsumed summaries", () => {
+test("mergeSubsumedSummaries matches tags case-insensitively", () => {
+    const removed: CompressSummary[] = [
+        {
+            anchorMessageId: "a1",
+            summary: `${PREFIX}Older summary A`,
+        },
+    ]
+
+    const merged = mergeSubsumedSummaries(removed, "Header\n{sumMary_0}\nFooter", "summary_11")
+
+    assert.equal(merged, `Header\n${WRAP("summary_0", "Older summary A")}\nFooter`)
+})
+
+test("mergeSubsumedSummaries uses existing summary names when already wrapped", () => {
+    const removed: CompressSummary[] = [
+        {
+            anchorMessageId: "a1",
+            summary: `${PREFIX}${WRAP("summary_4", "Prior block four")}`,
+        },
+        {
+            anchorMessageId: "a2",
+            summary: `${PREFIX}${WRAP("summary_9", "Prior block nine")}`,
+        },
+    ]
+
+    const merged = mergeSubsumedSummaries(
+        removed,
+        "Use this one: {Summary_9}\nThen later: {SUMMARY_4}",
+        "summary_11",
+    )
+
+    assert.equal(
+        merged,
+        `Use this one: ${WRAP("summary_9", "Prior block nine")}\nThen later: ${WRAP("summary_4", "Prior block four")}`,
+    )
+})
+
+test("mergeSubsumedSummaries appends overlap notice and summaries when no tags are used", () => {
+    const removed: CompressSummary[] = [
+        {
+            anchorMessageId: "a1",
+            summary: `${PREFIX}Older summary A`,
+        },
+        {
+            anchorMessageId: "a2",
+            summary: `${PREFIX}Older summary B`,
+        },
+    ]
+
+    const merged = mergeSubsumedSummaries(removed, "Newest summary", "summary_5")
+
+    assert.equal(
+        merged,
+        `Newest summary\n\n${APPEND_NOTICE("summary_5", 2)}\n\n${WRAP("summary_0", "Older summary A")}\n\n${WRAP("summary_1", "Older summary B")}`,
+    )
+})
+
+test("mergeSubsumedSummaries appends unresolved summaries when only some tags are used", () => {
+    const removed: CompressSummary[] = [
+        {
+            anchorMessageId: "a1",
+            summary: `${PREFIX}Older summary A`,
+        },
+        {
+            anchorMessageId: "a2",
+            summary: `${PREFIX}Older summary B`,
+        },
+    ]
+
+    const merged = mergeSubsumedSummaries(removed, "Intro\n{summary_0}\nOutro", "summary_6")
+
+    assert.equal(
+        merged,
+        `Intro\n${WRAP("summary_0", "Older summary A")}\nOutro\n\n${APPEND_NOTICE("summary_6", 1)}\n\n${WRAP("summary_1", "Older summary B")}`,
+    )
+})
+
+test("mergeSubsumedSummaries ignores unknown tags and empty summaries", () => {
     const removed: CompressSummary[] = [
         {
             anchorMessageId: "a1",
@@ -39,7 +131,10 @@ test("mergeSubsumedSummaries ignores empty subsumed summaries", () => {
         },
     ]
 
-    const merged = mergeSubsumedSummaries(removed, "Newest summary")
+    const merged = mergeSubsumedSummaries(removed, "Start {sumMary_7} End", "summary_3")
 
-    assert.equal(merged, "Useful prior summary\n\nNewest summary")
+    assert.equal(
+        merged,
+        `Start  End\n\n${APPEND_NOTICE("summary_3", 1)}\n\n${WRAP("summary_0", "Useful prior summary")}`,
+    )
 })


### PR DESCRIPTION
When a new compress range includes prior summary anchors, carry their summary text forward instead of discarding it. This prevents recompression loops from losing previously captured context and adds regression coverage for summary merging.