### PR TITLE
fix: downgrade reasoning parts to text when metadata is stripped

### DIFF
--- a/lib/messages/reasoning-strip.ts
+++ b/lib/messages/reasoning-strip.ts
@@ -34,6 +34,12 @@ export function stripStaleMetadata(messages: WithParts[]): void {
             }
 
             const { metadata: _metadata, ...rest } = part
+            // Reasoning parts without metadata cannot produce valid `thinking`
+            // API blocks because the required `signature` lives in metadata.
+            // Downgrade to text to prevent `thinking.signature: Field required`.
+            if (part.type === "reasoning") {
+                return { ...rest, type: "text" }
+            }
             return rest
         })
     })


### PR DESCRIPTION
When `stripStaleMetadata` removes provider metadata (including `bedrock.signature`) from `reasoning` parts after a model change, the parts were kept as `type: "reasoning"`. Switching back to a thinking-enabled model (e.g., Claude Opus 4-7) causes the AI SDK to create `{type: "thinking"}` blocks without the required `signature` field, resulting in API validation errors ("messages.N.content.0.thinking.signature: Field required").

**Fix**: when metadata is stripped from a `reasoning` part, downgrade it to `type: "text"` — the thinking content is preserved as readable text, but the SDK won't construct invalid thinking blocks.

**Root cause flow**:
1. Fork (or model change) triggers `stripStaleMetadata`
2. Metadata containing `bedrock.signature` is stripped from reasoning parts
3. But `type: "reasoning"` was retained
4. On switching back to a thinking model, the AI SDK converts stored reasoning parts to `{type: "thinking"}` blocks
5. Without the `signature` field the API schema validation rejects the request
