### PR TITLE
fix: stale stats and incorrect token breakdown after Compaction

### DIFF
--- a/lib/commands/context.ts
+++ b/lib/commands/context.ts
@@ -86,7 +86,7 @@ function analyzeTokens(state: SessionState, messages: WithParts[]): TokenBreakdo
 
     let firstAssistant: AssistantMessage | undefined
     for (const msg of messages) {
-        if (msg.info.role === "assistant") {
+        if (msg.info.role === "assistant" && !isMessageCompacted(state, msg)) {
             const assistantInfo = msg.info as AssistantMessage
             if (
                 assistantInfo.tokens?.input > 0 ||
@@ -102,7 +102,7 @@ function analyzeTokens(state: SessionState, messages: WithParts[]): TokenBreakdo
     let lastAssistant: AssistantMessage | undefined
     for (let i = messages.length - 1; i >= 0; i--) {
         const msg = messages[i]
-        if (msg.info.role === "assistant") {
+        if (msg.info.role === "assistant" && !isMessageCompacted(state, msg)) {
             const assistantInfo = msg.info as AssistantMessage
             if (assistantInfo.tokens?.output > 0) {
                 lastAssistant = assistantInfo

--- a/lib/state/utils.ts
+++ b/lib/state/utils.ts
@@ -342,4 +342,11 @@ export function resetOnCompaction(state: SessionState): void {
         turnNudgeAnchors: new Set<string>(),
         iterationNudgeAnchors: new Set<string>(),
     }
+    state.stats = {
+        pruneTokenCounter: 0,
+        totalPruneTokens: 0,
+    }
+    state.systemPromptTokens = undefined
+    state.compressionTiming.startsByCallId.clear()
+    state.compressionTiming.pendingByCallId.clear()
 }


### PR DESCRIPTION
Closes #563

## What this PR does

Fixes two related bugs where DCP statistics become stale after OpenCode's `/Compaction` runs:

### Bug 1: `analyzeTokens` ignores compaction boundary
- `firstAssistant`/`lastAssistant` search loops now filter compacted messages via `isMessageCompacted()`
- This prevents stale pre-compaction token data from inflating `breakdown.system` and corrupting all category percentages

### Bug 2: `resetOnCompaction` misses state reset
- Now resets `state.stats`, `state.systemPromptTokens`, and `state.compressionTiming`
- Prevents stale pruned-token counts from appearing alongside zero tool/message counts

## Changes

| File | Change |
|---|---|
| `lib/commands/context.ts` | Add `!isMessageCompacted(state, msg)` to `firstAssistant` and `lastAssistant` search |
| `lib/state/utils.ts` | Reset `stats`, `systemPromptTokens`, `compressionTiming` in `resetOnCompaction` |

## Verification

- TypeScript compilation passes (`tsc --noEmit`)
- Full build succeeds (`npm run build`)
- Manually tested: `/Compaction` ? `/dcp context` now shows correct post-compaction stats