### PR TITLE
fix: account for current context growth in token usage

### DIFF
--- a/lib/token-utils.ts
+++ b/lib/token-utils.ts
@@ -31,10 +31,29 @@ export function getCurrentTokenUsage(state: SessionState, messages: WithParts[])
         const reasoning = assistantInfo.tokens?.reasoning || 0
         const cacheRead = assistantInfo.tokens?.cache?.read || 0
         const cacheWrite = assistantInfo.tokens?.cache?.write || 0
-        return input + output + reasoning + cacheRead + cacheWrite
+        const reportedUsage = input + output + reasoning + cacheRead + cacheWrite
+        return Math.max(reportedUsage, estimateCurrentMessageTokenUsage(state, messages))
     }
 
     return 0
+}
+
+function estimateCurrentMessageTokenUsage(state: SessionState, messages: WithParts[]): number {
+    let total = 0
+
+    for (const msg of messages) {
+        if (
+            state.lastCompaction > 0 &&
+            (msg.info.time.created < state.lastCompaction ||
+                (msg.info.summary === true && msg.info.time.created === state.lastCompaction))
+        ) {
+            continue
+        }
+
+        total += countAllMessageTokens(msg)
+    }
+
+    return total
 }
 
 export function getCurrentParams(

--- a/tests/token-usage.test.ts
+++ b/tests/token-usage.test.ts
@@ -279,6 +279,62 @@ test("isContextOverLimits extends the max threshold by active summary tokens", (
     assert.equal(overExtendedLimit.overMaxLimit, true)
 })
 
+test("isContextOverLimits accounts for context growth after latest assistant report", () => {
+    const sessionID = "ses_context_growth_after_report"
+    const reportedTotal = 1000 + 100 + 50 + 25
+    const messages: WithParts[] = [
+        {
+            info: {
+                id: "msg-assistant-reported",
+                role: "assistant",
+                sessionID,
+                agent: "assistant",
+                time: { created: 1 },
+                tokens: {
+                    input: 1000,
+                    output: 100,
+                    reasoning: 50,
+                    cache: {
+                        read: 25,
+                        write: 0,
+                    },
+                },
+            } as WithParts["info"],
+            parts: [textPart("msg-assistant-reported", sessionID, "assistant-part", "Done.")],
+        },
+        {
+            info: {
+                id: "msg-user-large-followup",
+                role: "user",
+                sessionID,
+                agent: "assistant",
+                time: { created: 2 },
+            } as WithParts["info"],
+            parts: [
+                textPart(
+                    "msg-user-large-followup",
+                    sessionID,
+                    "user-large-part",
+                    repeatedWord("payload", 5000),
+                ),
+            ],
+        },
+    ]
+    const state = createSessionState()
+
+    assert.ok(getCurrentTokenUsage(state, messages) > reportedTotal)
+
+    const overLimit = isContextOverLimits(
+        buildConfig(reportedTotal + 1, 1),
+        state,
+        undefined,
+        undefined,
+        messages,
+    )
+
+    assert.equal(overLimit.overMaxLimit, true)
+})
+
 test("isContextOverLimits does not extend the max threshold when summaryBuffer is disabled", () => {
     const messages = buildCompactedMessages()
     messages.push(buildPostCompactionAssistantMessage())


### PR DESCRIPTION
## Summary
- Use the greater of the latest reported assistant token usage and an estimate of the current transformed message payload when deciding context pressure.
- Keep stale post-compaction reported-token handling intact.
- Add a regression test for large context growth after the latest assistant token report.

## Why
DCP currently decides whether to inject max-context compression nudges from the latest successful assistant response token report. If large tool output or user content is added after that report, the next assembled request can exceed the provider context window before the model ever sees the max-context nudge. Estimating the current transformed messages lets DCP detect that growth before the next request is sent.

## Verification
- `node --import tsx --test tests/token-usage.test.ts`
- `npm run typecheck`
- `npm run format:check -- lib/token-utils.ts tests/token-usage.test.ts`
- `npm test`
- `npm run build`