### PR TITLE
feat: allow trailing commas in config schema

### DIFF
--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -5,6 +5,7 @@
     "description": "Configuration schema for the OpenCode Dynamic Context Pruning plugin",
     "type": "object",
     "additionalProperties": false,
+    "allowTrailingCommas": true,
     "properties": {
         "$schema": {
             "type": "string",


### PR DESCRIPTION
Uses extension defined in [vscode-json-languageservice][vscode-json]. Also works with Zed and probably other editors too.

[vscode-json]: https://github.com/microsoft/vscode-json-languageservice/blob/5d87d160f018533c4eb3b996b54252f900a1e062/src/jsonSchema.ts#L89

Already understood by DCP with https://github.com/Opencode-DCP/opencode-dynamic-context-pruning/blob/85b6f5ceba144fee9e65eb28dc36cab1b960e418/lib/config.ts#L794