### PR TITLE
fix: strip hallucinated mXXXX</parameter> fragments at end of responses

### DIFF
--- a/lib/messages/utils.ts
+++ b/lib/messages/utils.ts
@@ -7,6 +7,7 @@ const SUMMARY_ID_HASH_LENGTH = 16
 const DCP_BLOCK_ID_TAG_REGEX = /(<dcp-message-id(?=[\s>])[^>]*>)b\d+(<\/dcp-message-id>)/g
 const DCP_PAIRED_TAG_REGEX = /<dcp[^>]*>[\s\S]*?<\/dcp[^>]*>/gi
 const DCP_UNPAIRED_TAG_REGEX = /<\/?dcp[^>]*>/gi
+const DCP_TRAILING_MESSAGE_ID_FRAGMENT_REGEX = /\nm\d+<\/parameter>\s*$/
 
 const generateStableId = (prefix: string, seed: string): string => {
     const hash = createHash("sha256").update(seed).digest("hex").slice(0, SUMMARY_ID_HASH_LENGTH)
@@ -163,7 +164,10 @@ export const replaceBlockIdsWithBlocked = (text: string): string => {
 }
 
 export const stripHallucinationsFromString = (text: string): string => {
-    return text.replace(DCP_PAIRED_TAG_REGEX, "").replace(DCP_UNPAIRED_TAG_REGEX, "")
+    return text
+        .replace(DCP_TRAILING_MESSAGE_ID_FRAGMENT_REGEX, "")
+        .replace(DCP_PAIRED_TAG_REGEX, "")
+        .replace(DCP_UNPAIRED_TAG_REGEX, "")
 }
 
 export const stripHallucinations = (messages: WithParts[]): void => {

--- a/tests/message-priority.test.ts
+++ b/tests/message-priority.test.ts
@@ -814,6 +814,18 @@ test("hallucination stripping does not affect non-dcp tags", async () => {
     )
 })
 
+test("hallucination stripping removes trailing mXXXX</parameter> fragments", async () => {
+    assert.equal(
+        stripHallucinationsFromString("Report complete.\n\nm0340</parameter>\n\n"),
+        "Report complete.\n",
+    )
+    // Should not match mid-text references
+    assert.equal(
+        stripHallucinationsFromString("Look at m0340</parameter> in the middle of text"),
+        "Look at m0340</parameter> in the middle of text",
+    )
+})
+
 test("injectMessageIds skips empty assistant messages to avoid prefill (issue #463)", () => {
     const sessionID = "ses_empty_assistant"
     const messages: WithParts[] = [


### PR DESCRIPTION
Closes #555

## What this PR does

Models occasionally append `mXXXX</parameter>` as a trailing line in their output (confirmed in pre-strip text). `stripHallucinationsFromString` only matched opening `<dcp` tags, so this artifact passed through, got stored in history, and was fed back into subsequent context — creating a self-reinforcing feedback loop.

This adds a new regex `DCP_TRAILING_MESSAGE_ID_FRAGMENT_REGEX` that matches the pattern anchored at end-of-string with a required leading newline, ensuring it only strips the actual hallucination and never mid-text content.

## Changes

| File | Change |
|---|---|
| `lib/messages/utils.ts` | Add `DCP_TRAILING_MESSAGE_ID_FRAGMENT_REGEX` and apply it first in `stripHallucinationsFromString` |
| `tests/message-priority.test.ts` | Add test for trailing fragment stripping + mid-text non-match |

## Verification

- TypeScript compilation passes (`tsc --noEmit`)
- All 88 existing tests pass (`npm test`)
- New test validates trailing removal and mid-text preservation