### PR TITLE
fix: prevent DCP_PAIRED_TAG_REGEX from cross-matching injected message ID tags

### DIFF
--- a/lib/messages/utils.ts
+++ b/lib/messages/utils.ts
@@ -7,6 +7,7 @@ const SUMMARY_ID_HASH_LENGTH = 16
 const DCP_BLOCK_ID_TAG_REGEX = /(<dcp-message-id(?=[\s>])[^>]*>)b\d+(<\/dcp-message-id>)/g
 const DCP_PAIRED_TAG_REGEX = /<dcp[^>]*>[\s\S]*?<\/dcp[^>]*>/gi
 const DCP_UNPAIRED_TAG_REGEX = /<\/?dcp[^>]*>/gi
+const INJECTED_TAG_SUFFIX_REGEX = /\n<dcp-message-id[^>]*>m\d+<\/dcp-message-id>\s*$/
 
 const generateStableId = (prefix: string, seed: string): string => {
     const hash = createHash("sha256").update(seed).digest("hex").slice(0, SUMMARY_ID_HASH_LENGTH)
@@ -163,7 +164,8 @@ export const replaceBlockIdsWithBlocked = (text: string): string => {
 }
 
 export const stripHallucinationsFromString = (text: string): string => {
-    return text.replace(DCP_PAIRED_TAG_REGEX, "").replace(DCP_UNPAIRED_TAG_REGEX, "")
+    const safe = text.replace(INJECTED_TAG_SUFFIX_REGEX, "")
+    return safe.replace(DCP_PAIRED_TAG_REGEX, "").replace(DCP_UNPAIRED_TAG_REGEX, "")
 }
 
 export const stripHallucinations = (messages: WithParts[]): void => {

--- a/tests/message-priority.test.ts
+++ b/tests/message-priority.test.ts
@@ -814,6 +814,19 @@ test("hallucination stripping does not affect non-dcp tags", async () => {
     )
 })
 
+test("hallucination stripping handles injected message ID suffix without truncating content", async () => {
+    // Simulates a message that had injectMessageIds append <dcp-message-id>m0222</dcp-message-id>,
+    // AND contains a natural-language mention of <dcp-message-id> in the content body.
+    // Without the fix, DCP_PAIRED_TAG_REGEX matches from the in-content opening tag to the
+    // injected closing tag, truncating everything between them.
+    assert.equal(
+        stripHallucinationsFromString(
+            "The tag called <dcp-message-id> is used for tracking.\n<dcp-message-id>m0222</dcp-message-id>\n",
+        ),
+        "The tag called  is used for tracking.",
+    )
+})
+
 test("injectMessageIds skips empty assistant messages to avoid prefill (issue #463)", () => {
     const sessionID = "ses_empty_assistant"
     const messages: WithParts[] = [


### PR DESCRIPTION
Closes #556

## What this PR does

When `stripHallucinations` processes messages from prior cycles that already had `<dcp-message-id>mXXXX</dcp-message-id>` injected by `injectMessageIds`, `DCP_PAIRED_TAG_REGEX` can match from an in-text natural-language mention of `<dcp-message-id>` to the injected closing `</dcp-message-id>` tag. This truncates all content between them.

This adds `INJECTED_TAG_SUFFIX_REGEX` as a pre-processing step: strip the legitimately injected tag suffix before running the paired regex, so it only sees genuine hallucinated tag pairs. `injectMessageIds` re-adds the tag later in the same cycle.

## Changes

| File | Change |
|---|---|
| `lib/messages/utils.ts` | Add `INJECTED_TAG_SUFFIX_REGEX`; strip injected tag suffix before `DCP_PAIRED_TAG_REGEX` |
| `tests/message-priority.test.ts` | Add test verifying content after in-text DCP tag mentions is preserved |

## Verification

- TypeScript compilation passes (`tsc --noEmit`)
- All 88 tests pass (`npm test`)