### PR TITLE
fix: normalize a single backslash so protectedFilePatterns work on Windows

### DIFF
--- a/lib/protected-patterns.ts
+++ b/lib/protected-patterns.ts
@@ -1,5 +1,9 @@
 function normalizePath(input: string): string {
-    return input.replaceAll("\\\\", "/")
+    // A single backslash. In source, "\\" is the one-character string; the
+    // previous "\\\\" was a *two*-character string, so it only ever matched a
+    // doubled separator -- which a real Windows path does not contain. The
+    // normalisation was therefore a no-op on the only platform that needs it.
+    return input.replaceAll("\\", "/")
 }
 
 function escapeRegExpChar(ch: string): string {

--- a/tests/protected-patterns.test.ts
+++ b/tests/protected-patterns.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {
+    getFilePathsFromParameters,
+    isFilePathProtected,
+    isToolNameProtected,
+    matchesGlob,
+} from "../lib/protected-patterns"
+
+// A single backslash, built from its char code so the intent survives any later
+// reformatting of this file. The bug being pinned here was precisely an escaping
+// mistake in a string literal, so the tests avoid writing one by hand.
+const BS = String.fromCharCode(92)
+const winPath = (...segments: string[]) => segments.join(BS)
+
+test("matchesGlob treats a Windows separator as a path separator", () => {
+    // `protectedFilePatterns` is documented with forward slashes ("**/*.config.ts"),
+    // but on Windows the tool parameters carry backslashes. Both sides are
+    // normalised, so the same pattern must match either spelling of the same file.
+    const path = winPath("C:", "repo", "src", "config", "secrets.ts")
+
+    assert.equal(matchesGlob(path, "**/secrets.ts"), true)
+    assert.equal(matchesGlob(path, "**/config/*.ts"), true)
+    assert.equal(matchesGlob(path, "C:/repo/src/**"), true)
+    assert.equal(matchesGlob(path, "**/*.ts"), true)
+})
+
+test("matchesGlob accepts a pattern written with Windows separators", () => {
+    // Normalisation applies to the pattern too, so a user who copies a path out of
+    // Explorer and uses it as a pattern gets the same result as the documented form.
+    const pattern = winPath("**", "config", "*.ts")
+
+    assert.equal(matchesGlob("C:/repo/src/config/secrets.ts", pattern), true)
+    assert.equal(matchesGlob(winPath("C:", "repo", "src", "config", "secrets.ts"), pattern), true)
+})
+
+test("a single-segment wildcard still does not cross a Windows separator", () => {
+    // `*` is defined as "[^/]*". Normalisation must convert separators rather than
+    // erase them, or `*` would silently start matching across directories.
+    assert.equal(matchesGlob(winPath("src", "config", "secrets.ts"), "src/*"), false)
+    assert.equal(matchesGlob(winPath("src", "config", "secrets.ts"), "src/*/*.ts"), true)
+    assert.equal(matchesGlob(winPath("src", "secrets.ts"), "src/*"), true)
+})
+
+test("isFilePathProtected protects a Windows path the user configured", () => {
+    // The end-to-end shape: a `read` tool call on Windows, checked against the
+    // documented pattern style. This is the assertion that failed before the fix --
+    // the file was protected on POSIX and unprotected on Windows.
+    const patterns = ["**/secrets.ts", "**/.env"]
+
+    for (const path of [
+        "C:/repo/src/config/secrets.ts",
+        winPath("C:", "repo", "src", "config", "secrets.ts"),
+    ]) {
+        const paths = getFilePathsFromParameters("read", { filePath: path })
+        assert.equal(isFilePathProtected(paths, patterns), true, `not protected: ${path}`)
+    }
+})
+
+test("isFilePathProtected still returns false for a genuinely unmatched path", () => {
+    // The fix must widen matching only for separators, not for anything else.
+    const paths = getFilePathsFromParameters("read", {
+        filePath: winPath("C:", "repo", "src", "main.ts"),
+    })
+
+    assert.equal(isFilePathProtected(paths, ["**/secrets.ts"]), false)
+    assert.equal(isFilePathProtected(paths, []), false)
+    assert.equal(isFilePathProtected([], ["**/*.ts"]), false)
+})
+
+test("multiedit and apply_patch paths are protected on Windows too", () => {
+    // These two tools carry paths in shapes of their own, so they need their own
+    // coverage: a nested `edits` array and paths embedded in patch text.
+    const patterns = ["**/secrets.ts"]
+
+    const multiedit = getFilePathsFromParameters("multiedit", {
+        filePath: winPath("src", "main.ts"),
+        edits: [{ filePath: winPath("src", "config", "secrets.ts") }],
+    })
+    assert.equal(isFilePathProtected(multiedit, patterns), true)
+
+    const patch = getFilePathsFromParameters("apply_patch", {
+        patchText: `*** Update File: ${winPath("src", "config", "secrets.ts")}\n@@\n-a\n+b\n`,
+    })
+    assert.equal(isFilePathProtected(patch, patterns), true)
+})
+
+test("isToolNameProtected is unaffected by separator normalisation", () => {
+    // Tool names contain no separators; this pins that the shared helper does not
+    // change their behaviour.
+    assert.equal(isToolNameProtected("bash", ["bash"]), true)
+    assert.equal(isToolNameProtected("bash", ["ba*"]), true)
+    assert.equal(isToolNameProtected("bash", ["read"]), false)
+    assert.equal(isToolNameProtected("bash", []), false)
+    assert.equal(isToolNameProtected("", ["bash"]), false)
+})
+
+test("matchesGlob rejects an empty pattern and handles regex metacharacters", () => {
+    // Pattern text is interpolated into a RegExp, so characters that mean something
+    // there must be matched literally.
+    assert.equal(matchesGlob("a/b.ts", ""), false)
+    assert.equal(matchesGlob("src/a+b(1).ts", "src/a+b(1).ts"), true)
+    assert.equal(matchesGlob("src/axb1.ts", "src/a+b(1).ts"), false)
+})


### PR DESCRIPTION
Fixes #592

### What was wrong

`normalizePath` searched for `"\\\\"` — in source, the **two-character** string `\\`. A path from the filesystem contains **single** separators, so nothing was ever replaced. The function exists solely to make Windows paths comparable to forward-slash glob patterns, and it was inert on the only platform that needs it.

`protectedFilePatterns` consequently protected a file on POSIX and silently failed to protect the same file on Windows:

| pattern | `C:/repo/src/config/secrets.ts` | `C:\repo\src\config\secrets.ts` |
| --- | --- | --- |
| `**/secrets.ts` | `true` | **`false`** |
| `**/config/*.ts` | `true` | **`false`** |
| `C:/repo/src/**` | `true` | **`false`** |
| `**/*.ts` | `true` | `true` |

That last row is why this survived: `**` compiles to `.*`, which spans backslashes, so a user who tests with `**/*.ts` sees protection working. Every pattern that names a directory or an exact file did nothing.

`isFilePathProtected` is the guard that keeps configured files out of pruning, consulted from `compress/protected-content.ts:138`, `commands/sweep.ts:184`/`:201`, `strategies/deduplication.ts:60`, and `strategies/purge-errors.ts:62`. On Windows all of them saw `false` for paths the user explicitly asked to protect. The failure was silent: config parses, schema validates, nothing logs.

### What changed

```diff
-return input.replaceAll("\\\\", "/")
+return input.replaceAll("\\", "/")
```

One character. `replaceAll` takes a string, not a regex, so no regex-level escaping belongs there.

Because `normalizePath` is applied to the pattern as well as the path, a pattern written with Windows separators now also works — which is what a user copying a path out of Explorer naturally produces.

**What deliberately does not change:** separators are *converted*, not stripped. `*` compiles to `[^/]*` and must not cross a directory boundary, so `src/*` still does not match `src\config\secrets.ts`. A fix that removed backslashes instead of translating them would break that quietly, so it has a test of its own.

### Verification

- `npm test`: **95 pass / 0 fail** (was 87 — exactly +8, the new tests).
- With `lib/protected-patterns.ts` reverted to `master` and the new tests kept: **5 fail / 90 pass**. The three tests that pass either way are the platform-neutral ones (tool-name matching, empty pattern, regex metacharacters) — they are there to pin that this change does not widen matching beyond separators.
- `npm run typecheck`: clean.
- `prettier --check` on both files: clean.

### Tests added

`tests/protected-patterns.test.ts` — the module had no test file. 8 tests:

- the same file, spelled with either separator, matches the documented pattern styles
- a pattern written with Windows separators works against either spelling
- **`*` still does not cross a normalised separator** — the property a strip-instead-of-convert fix would break
- `isFilePathProtected` end-to-end through `getFilePathsFromParameters("read", …)`, which is the shape the call sites actually pass
- a genuinely unmatched path, an empty pattern list, and an empty path list all still return `false`
- `multiedit` (nested `edits[].filePath`) and `apply_patch` (paths embedded in `patchText`) on Windows, since each carries paths in its own shape
- `isToolNameProtected` unchanged, and empty-pattern / regex-metacharacter handling in `matchesGlob`

The tests build the backslash with `String.fromCharCode(92)` rather than writing a literal. The bug being pinned *was* an escaping mistake in a string literal, so the tests avoid depending on one.
