### PR TITLE
fix: reset compress-pending manual mode after compression

### DIFF
--- a/lib/compress/pipeline.ts
+++ b/lib/compress/pipeline.ts
@@ -85,7 +85,15 @@ export async function finalizeSession(
     entries: NotificationEntry[],
     batchTopic: string | undefined,
 ): Promise<void> {
-    ctx.state.manualMode = ctx.state.manualMode === "active" ? "active" : false
+    if (ctx.state.manualMode === "compress-pending") {
+        ctx.state.manualMode = false
+        await refreshManualMode(
+            ctx.state,
+            toolCtx.sessionID,
+            ctx.logger,
+            ctx.config.manualMode.enabled,
+        )
+    }
     applyPendingCompressionDurations(ctx.state)
     await saveSessionState(ctx.state, ctx.logger)
 

--- a/lib/compress/pipeline.ts
+++ b/lib/compress/pipeline.ts
@@ -85,7 +85,7 @@ export async function finalizeSession(
     entries: NotificationEntry[],
     batchTopic: string | undefined,
 ): Promise<void> {
-    ctx.state.manualMode = ctx.state.manualMode ? "active" : false
+    ctx.state.manualMode = ctx.state.manualMode === "active" ? "active" : false
     applyPendingCompressionDurations(ctx.state)
     await saveSessionState(ctx.state, ctx.logger)
 

--- a/tests/finalize-session.test.ts
+++ b/tests/finalize-session.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { finalizeSession } from "../lib/compress/pipeline"
+import type { PluginConfig } from "../lib/config"
+import { Logger } from "../lib/logger"
+import {
+    createSessionState,
+    loadManualModeSetting,
+    type WithParts,
+} from "../lib/state"
+
+function buildConfig(): PluginConfig {
+    return {
+        enabled: true,
+        debug: false,
+        pruneNotification: "off",
+        pruneNotificationType: "chat",
+        commands: { enabled: true, protectedTools: [] },
+        manualMode: { enabled: false, automaticStrategies: true },
+        turnProtection: { enabled: false, turns: 4 },
+        experimental: { allowSubAgents: false, customPrompts: false },
+        protectedFilePatterns: [],
+        compress: {
+            mode: "message",
+            permission: "allow",
+            showCompression: false,
+            maxContextLimit: 150000,
+            minContextLimit: 50000,
+            nudgeFrequency: 5,
+            iterationNudgeThreshold: 15,
+            nudgeForce: "soft",
+            protectedTools: ["task"],
+            protectTags: false,
+            protectUserMessages: false,
+        },
+        strategies: {
+            deduplication: { enabled: true, protectedTools: [] },
+            purgeErrors: { enabled: true, turns: 4, protectedTools: [] },
+        },
+    } as PluginConfig
+}
+
+function buildToolContext(state: ReturnType<typeof createSessionState>) {
+    return {
+        client: { session: { get: async () => ({}) } },
+        state,
+        logger: new Logger(false),
+        config: buildConfig(),
+        prompts: {
+            reload() {},
+            getRuntimePrompts() {
+                return {} as any
+            },
+        },
+    }
+}
+
+test("finalizeSession resets compress-pending to auto mode", async () => {
+    const sessionId = `finalize-compress-pending-${Date.now()}`
+    const state = createSessionState()
+    state.sessionId = sessionId
+    state.manualMode = "compress-pending"
+
+    await finalizeSession(
+        buildToolContext(state) as any,
+        { sessionID: sessionId, metadata: () => {}, ask: async () => {} },
+        [] as WithParts[],
+        [],
+        undefined,
+    )
+
+    assert.equal(state.manualMode, false)
+
+    const persisted = await loadManualModeSetting(sessionId, new Logger(false))
+    assert.equal(persisted, false)
+})
+
+test("finalizeSession preserves explicit active manual mode", async () => {
+    const sessionId = `finalize-active-manual-${Date.now()}`
+    const state = createSessionState()
+    state.sessionId = sessionId
+    state.manualMode = "active"
+
+    await finalizeSession(
+        buildToolContext(state) as any,
+        { sessionID: sessionId, metadata: () => {}, ask: async () => {} },
+        [] as WithParts[],
+        [],
+        undefined,
+    )
+
+    assert.equal(state.manualMode, "active")
+
+    const persisted = await loadManualModeSetting(sessionId, new Logger(false))
+    assert.equal(persisted, true)
+})

--- a/tests/finalize-session.test.ts
+++ b/tests/finalize-session.test.ts
@@ -6,17 +6,18 @@ import { Logger } from "../lib/logger"
 import {
     createSessionState,
     loadManualModeSetting,
+    saveManualModeSetting,
     type WithParts,
 } from "../lib/state"
 
-function buildConfig(): PluginConfig {
+function buildConfig(manualMode = false): PluginConfig {
     return {
         enabled: true,
         debug: false,
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        manualMode: { enabled: false, automaticStrategies: true },
+        manualMode: { enabled: manualMode, automaticStrategies: true },
         turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
@@ -40,12 +41,12 @@ function buildConfig(): PluginConfig {
     } as PluginConfig
 }
 
-function buildToolContext(state: ReturnType<typeof createSessionState>) {
+function buildToolContext(state: ReturnType<typeof createSessionState>, manualMode = false) {
     return {
         client: { session: { get: async () => ({}) } },
         state,
         logger: new Logger(false),
-        config: buildConfig(),
+        config: buildConfig(manualMode),
         prompts: {
             reload() {},
             getRuntimePrompts() {
@@ -75,14 +76,37 @@ test("finalizeSession resets compress-pending to auto mode", async () => {
     assert.equal(persisted, false)
 })
 
-test("finalizeSession preserves explicit active manual mode", async () => {
-    const sessionId = `finalize-active-manual-${Date.now()}`
+test("finalizeSession restores persisted manual mode after compression", async () => {
+    const sessionId = `finalize-persisted-manual-${Date.now()}`
+    const logger = new Logger(false)
+    await saveManualModeSetting(sessionId, true, logger)
+
     const state = createSessionState()
     state.sessionId = sessionId
-    state.manualMode = "active"
+    state.manualMode = "compress-pending"
 
     await finalizeSession(
         buildToolContext(state) as any,
+        { sessionID: sessionId, metadata: () => {}, ask: async () => {} },
+        [] as WithParts[],
+        [],
+        undefined,
+    )
+
+    assert.equal(state.manualMode, "active")
+
+    const persisted = await loadManualModeSetting(sessionId, logger)
+    assert.equal(persisted, true)
+})
+
+test("finalizeSession restores configured manual mode after compression", async () => {
+    const sessionId = `finalize-configured-manual-${Date.now()}`
+    const state = createSessionState()
+    state.sessionId = sessionId
+    state.manualMode = "compress-pending"
+
+    await finalizeSession(
+        buildToolContext(state, true) as any,
         { sessionID: sessionId, metadata: () => {}, ask: async () => {} },
         [] as WithParts[],
         [],


### PR DESCRIPTION
## Summary
- Reset temporary `compress-pending` state after `/dcp-compress`.
- Restore the persisted session setting or configured manual-mode default instead of always enabling or disabling manual mode.
- Cover automatic, persisted manual, and configured manual modes.

Fixes #590

## Verification
- `npm run format:check`
- `npm run typecheck`
- `npm test` (95 tests)
- `npm run build`
- `npm audit --audit-level=high`