### PR TITLE
Fix five v2-port bugs: nudges never fire, /dcp-compress crashes on every path

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,7 @@ import {
 } from "./lib/hooks"
 import { configureClientAuth, isSecureMode } from "./lib/auth"
 import { startAutoUpdate } from "./lib/update"
+import { buildV2ClientCompat } from "./lib/v2-client-shim"
 
 export const Plugin = {
     define<T extends { id: string; setup: (ctx: any) => any }>(definition: T): T {
@@ -44,10 +45,17 @@ export default Plugin.define({
             agents: {},
         }
 
-        const client = ctx?.client
+        // v2's setup ctx has no `.client` field at all (confirmed against the
+        // real @opencode-ai/plugin Context type) -- `ctx?.client` is always
+        // undefined under v2, which is why every client.* call below crashed
+        // or silently no-op'd. Fall back to a compatibility shim built from
+        // the real v2 domains (ctx.catalog, ctx.session) wherever one exists;
+        // see lib/v2-client-shim.ts for what is and is not translatable.
+        const realClient = ctx?.client
+        const client = realClient ?? buildV2ClientCompat(ctx)
 
-        if (isSecureMode() && client) {
-            configureClientAuth(client)
+        if (isSecureMode() && realClient) {
+            configureClientAuth(realClient)
         }
 
         logger.info("DCP initialized", {

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,3 @@
-import type { Plugin } from "@opencode-ai/plugin"
 import { getConfig } from "./lib/config"
 import { createCompressMessageTool, createCompressRangeTool } from "./lib/compress"
 import {
@@ -12,6 +11,7 @@ import { PromptStore } from "./lib/prompts/store"
 import {
     createChatMessageTransformHandler,
     createCommandExecuteHandler,
+    createContextHandler,
     createEventHandler,
     createSystemPromptHandler,
     createTextCompleteHandler,
@@ -19,7 +19,206 @@ import {
 import { configureClientAuth, isSecureMode } from "./lib/auth"
 import { startAutoUpdate } from "./lib/update"
 
-const server: Plugin = (async (ctx) => {
+export const Plugin = {
+    define<T extends { id: string; setup: (ctx: any) => any }>(definition: T): T {
+        return definition
+    },
+}
+
+export default Plugin.define({
+    id: "opencode-dcp",
+    async setup(ctx: any) {
+        const config = getConfig(ctx)
+
+        if (!config.enabled) {
+            return async () => {}
+        }
+
+        const logger = new Logger(config.debug)
+        const state = createSessionState()
+        const directory = ctx?.directory || (ctx?.app?.workspace?.directory ?? process.cwd())
+        const prompts = new PromptStore(logger, directory, config.experimental.customPrompts)
+        const hostPermissions: HostPermissionSnapshot = {
+            global: undefined,
+            agents: {},
+        }
+
+        const client = ctx?.client
+
+        if (isSecureMode() && client) {
+            configureClientAuth(client)
+        }
+
+        logger.info("DCP initialized", {
+            strategies: config.strategies,
+        })
+
+        startAutoUpdate(ctx, config.autoUpdate)
+
+        const compressToolContext = {
+            client,
+            state,
+            logger,
+            config,
+            prompts,
+        }
+
+        const registrations: Array<{ dispose(): Promise<void> | void }> = []
+
+        // 1. Session context hook (migrates context transformation and pruning)
+        if (ctx.session?.hook) {
+            const contextHandler = createContextHandler(
+                client,
+                state,
+                logger,
+                config,
+                prompts,
+                hostPermissions,
+            )
+            const reg = await ctx.session.hook("context", async (event: any) => {
+                await contextHandler(event)
+            })
+            if (reg && typeof reg.dispose === "function") {
+                registrations.push(reg)
+            }
+        }
+
+        // 2. Tool registration (using ctx.tool.transform)
+        if (ctx.tool?.transform && config.compress.permission !== "deny") {
+            const toolInstance =
+                config.compress.mode === "message"
+                    ? createCompressMessageTool(compressToolContext)
+                    : createCompressRangeTool(compressToolContext)
+
+            const input = {
+                type: "object",
+                properties: {
+                    topic: {
+                        type: "string",
+                        description:
+                            config.compress.mode === "message"
+                                ? "Short label (3-5 words) for the overall batch - e.g., 'Closed Research Notes'"
+                                : "Short label (3-5 words) for display - e.g., 'Auth System Exploration'",
+                    },
+                    content: {
+                        type: "array",
+                        description:
+                            config.compress.mode === "message"
+                                ? "Batch of individual message summaries to create in one tool call"
+                                : "One or more ranges to compress, each with start/end boundaries and a summary",
+                        items:
+                            config.compress.mode === "message"
+                                ? {
+                                      type: "object",
+                                      properties: {
+                                          messageId: {
+                                              type: "string",
+                                              description:
+                                                  "Raw message ID to compress (e.g. m0001)",
+                                          },
+                                          topic: {
+                                              type: "string",
+                                              description:
+                                                  "Short label (3-5 words) for this one message summary",
+                                          },
+                                          summary: {
+                                              type: "string",
+                                              description:
+                                                  "Complete technical summary replacing that one message",
+                                          },
+                                      },
+                                      required: ["messageId", "topic", "summary"],
+                                  }
+                                : {
+                                      type: "object",
+                                      properties: {
+                                          startId: {
+                                              type: "string",
+                                              description:
+                                                  "Message or block ID marking the beginning of range (e.g. m0001, b2)",
+                                          },
+                                          endId: {
+                                              type: "string",
+                                              description:
+                                                  "Message or block ID marking the end of range (e.g. m0012, b5)",
+                                          },
+                                          summary: {
+                                              type: "string",
+                                              description:
+                                                  "Complete technical summary replacing all content in range",
+                                          },
+                                      },
+                                      required: ["startId", "endId", "summary"],
+                                  },
+                    },
+                },
+                required: ["topic", "content"],
+            }
+
+            const toolDef = {
+                name: "compress",
+                description: (toolInstance as any).description,
+                input,
+                async execute(input: any, toolCtx: any) {
+                    const text = await (toolInstance as any).execute(input, toolCtx)
+                    return { content: [{ type: "text", text }] }
+                },
+            }
+
+            const toolReg = await ctx.tool.transform((draft: any) => {
+                draft.add(toolDef)
+            })
+            if (toolReg && typeof toolReg.dispose === "function") {
+                registrations.push(toolReg)
+            }
+        }
+
+        // 3. Command registration (using ctx.command.transform)
+        if (
+            ctx.command?.transform &&
+            config.commands.enabled &&
+            config.compress.permission !== "deny"
+        ) {
+            const commandReg = await ctx.command.transform((draft: any) => {
+                if (draft && typeof draft.update === "function") {
+                    draft.update("dcp-compress", (cmd: any) => {
+                        if (cmd && typeof cmd === "object") {
+                            cmd.template = ""
+                            cmd.description =
+                                "Trigger DCP manual compression with: /dcp-compress [focus]"
+                        }
+                    })
+                }
+            })
+            if (commandReg && typeof commandReg.dispose === "function") {
+                registrations.push(commandReg)
+            }
+        }
+
+        // 4. Event subscription (using ctx.event.subscribe)
+        if (ctx.event?.subscribe) {
+            const eventHandler = createEventHandler(state, logger)
+            const eventReg = await ctx.event.subscribe(async (event: any) => {
+                await eventHandler({ event })
+            })
+            if (eventReg && typeof eventReg.dispose === "function") {
+                registrations.push(eventReg)
+            }
+        }
+
+        // 5. Cleanup
+        return async () => {
+            await Promise.all(
+                registrations
+                    .filter((r) => r && typeof r.dispose === "function")
+                    .map((r) => r.dispose()),
+            )
+        }
+    },
+})
+
+/** Legacy v1 plugin factory retained for backwards-compatibility */
+export const server = async (ctx: any) => {
     const config = getConfig(ctx)
 
     if (!config.enabled) {
@@ -36,7 +235,6 @@ const server: Plugin = (async (ctx) => {
 
     if (isSecureMode()) {
         configureClientAuth(ctx.client)
-        // logger.info("Secure mode detected, configured client authentication")
     }
 
     logger.info("DCP initialized", {
@@ -86,7 +284,7 @@ const server: Plugin = (async (ctx) => {
                         : createCompressRangeTool(compressToolContext),
             }),
         },
-        config: async (opencodeConfig) => {
+        config: async (opencodeConfig: any) => {
             if (
                 config.compress.permission !== "deny" &&
                 compressDisabledByOpencode(opencodeConfig.permission)
@@ -125,13 +323,11 @@ const server: Plugin = (async (ctx) => {
 
             hostPermissions.global = opencodeConfig.permission
             hostPermissions.agents = Object.fromEntries(
-                Object.entries(opencodeConfig.agent ?? {}).map(([name, agent]) => [
+                Object.entries(opencodeConfig.agent ?? {}).map(([name, agent]: [string, any]) => [
                     name,
                     agent?.permission,
                 ]),
             )
         },
     }
-}) satisfies Plugin
-
-export default server
+}

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import { getConfig } from "./lib/config"
 import { createCompressMessageTool, createCompressRangeTool } from "./lib/compress"
+import { COMPRESS_TRIGGER_PROMPT } from "./lib/commands/manual"
 import {
     compressDisabledByOpencode,
     hasExplicitToolPermission,
@@ -174,16 +175,27 @@ export default Plugin.define({
         }
 
         // 3. Command registration (using ctx.command.transform)
+        //
+        // v2 has no command-execution hook (`CommandDomain` only exposes
+        // `transform`/`reload`, never a per-invocation intercept like v1's
+        // `command.execute.before`). A command's `template` IS the entire
+        // prompt sent to the model -- there is nothing left to fill it in
+        // dynamically at execute time. So `dcp-compress` must carry the real
+        // compress-trigger instructions in its static template rather than
+        // an empty string (which used to rely on `createCommandExecuteHandler`
+        // to replace it before it was empty on submit).
         if (
             ctx.command?.transform &&
             config.commands.enabled &&
             config.compress.permission !== "deny"
         ) {
+            const compressCommandTemplate = `${COMPRESS_TRIGGER_PROMPT}\n\nIf additional user focus is specified below, prioritize compressing content related to it: $ARGUMENTS`
+
             const commandReg = await ctx.command.transform((draft: any) => {
                 if (draft && typeof draft.update === "function") {
                     draft.update("dcp-compress", (cmd: any) => {
                         if (cmd && typeof cmd === "object") {
-                            cmd.template = ""
+                            cmd.template = compressCommandTemplate
                             cmd.description =
                                 "Trigger DCP manual compression with: /dcp-compress [focus]"
                         }

--- a/lib/commands/manual.ts
+++ b/lib/commands/manual.ts
@@ -20,7 +20,7 @@ const MANUAL_MODE_ON = "Manual mode is now ON. Use /dcp-compress to trigger cont
 
 const MANUAL_MODE_OFF = "Manual mode is now OFF."
 
-const COMPRESS_TRIGGER_PROMPT = [
+export const COMPRESS_TRIGGER_PROMPT = [
     "<compress triggered manually>",
     "Manual mode trigger received. You must now use the compress tool.",
     "Find the most significant completed conversation content that can be compressed into a high-fidelity technical summary.",

--- a/lib/compress/index.ts
+++ b/lib/compress/index.ts
@@ -1,3 +1,3 @@
-export { ToolContext } from "./types"
+export type { ToolContext } from "./types"
 export { createCompressMessageTool } from "./message"
 export { createCompressRangeTool } from "./range"

--- a/lib/compress/message.ts
+++ b/lib/compress/message.ts
@@ -1,4 +1,3 @@
-import { tool } from "@opencode-ai/plugin"
 import type { ToolContext } from "./types"
 import { countTokens } from "../token-utils"
 import { MESSAGE_FORMAT_EXTENSION } from "../prompts/extensions/tool"
@@ -13,39 +12,13 @@ import {
 } from "./state"
 import type { CompressMessageToolArgs } from "./types"
 
-function buildSchema() {
-    return {
-        topic: tool.schema
-            .string()
-            .describe(
-                "Short label (3-5 words) for the overall batch - e.g., 'Closed Research Notes'",
-            ),
-        content: tool.schema
-            .array(
-                tool.schema.object({
-                    messageId: tool.schema
-                        .string()
-                        .describe("Raw message ID to compress (e.g. m0001)"),
-                    topic: tool.schema
-                        .string()
-                        .describe("Short label (3-5 words) for this one message summary"),
-                    summary: tool.schema
-                        .string()
-                        .describe("Complete technical summary replacing that one message"),
-                }),
-            )
-            .describe("Batch of individual message summaries to create in one tool call"),
-    }
-}
-
-export function createCompressMessageTool(ctx: ToolContext): ReturnType<typeof tool> {
+export function createCompressMessageTool(ctx: ToolContext) {
     ctx.prompts.reload()
     const runtimePrompts = ctx.prompts.getRuntimePrompts()
 
-    return tool({
+    return {
         description: runtimePrompts.compressMessage + MESSAGE_FORMAT_EXTENSION,
-        args: buildSchema(),
-        async execute(args, toolCtx) {
+        async execute(args: CompressMessageToolArgs, toolCtx: any) {
             const input = args as CompressMessageToolArgs
             validateArgs(input)
             const callId =
@@ -141,5 +114,5 @@ export function createCompressMessageTool(ctx: ToolContext): ReturnType<typeof t
 
             return formatResult(plans.length, skippedIssues, skippedCount)
         },
-    })
+    }
 }

--- a/lib/compress/pipeline.ts
+++ b/lib/compress/pipeline.ts
@@ -12,13 +12,13 @@ import type { SearchContext } from "./types"
 import { applyPendingCompressionDurations } from "./timing"
 
 interface RunContext {
-    ask(input: {
+    ask?(input: {
         permission: string
         patterns: string[]
         always: string[]
         metadata: Record<string, unknown>
     }): Promise<void>
-    metadata(input: { title: string }): void
+    metadata?(input: { title: string }): void
     sessionID: string
 }
 
@@ -47,14 +47,23 @@ export async function prepareSession(
         )
     }
 
-    await toolCtx.ask({
-        permission: "compress",
-        patterns: ["*"],
-        always: ["*"],
-        metadata: {},
-    })
+    // v1's tool ctx offered ask()/metadata() (interactive permission prompt,
+    // UI title) that v2's real Tool.Context (@opencode-ai/plugin promise/effect
+    // tool.d.ts: sessionID/agent/messageID/id/progress only) does not expose at
+    // all. Calling them unconditionally crashed every compress execution under
+    // v2 with an opaque tool failure. Guard both as v1-only conveniences.
+    if (typeof toolCtx.ask === "function") {
+        await toolCtx.ask({
+            permission: "compress",
+            patterns: ["*"],
+            always: ["*"],
+            metadata: {},
+        })
+    }
 
-    toolCtx.metadata({ title })
+    if (typeof toolCtx.metadata === "function") {
+        toolCtx.metadata({ title })
+    }
 
     const rawMessages = await fetchSessionMessages(ctx.client, toolCtx.sessionID)
 

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -1,4 +1,3 @@
-import { tool } from "@opencode-ai/plugin"
 import type { ToolContext } from "./types"
 import { countTokens } from "../token-utils"
 import { RANGE_FORMAT_EXTENSION } from "../prompts/extensions/tool"
@@ -26,41 +25,13 @@ import {
 } from "./state"
 import type { CompressRangeToolArgs } from "./types"
 
-function buildSchema() {
-    return {
-        topic: tool.schema
-            .string()
-            .describe("Short label (3-5 words) for display - e.g., 'Auth System Exploration'"),
-        content: tool.schema
-            .array(
-                tool.schema.object({
-                    startId: tool.schema
-                        .string()
-                        .describe(
-                            "Message or block ID marking the beginning of range (e.g. m0001, b2)",
-                        ),
-                    endId: tool.schema
-                        .string()
-                        .describe("Message or block ID marking the end of range (e.g. m0012, b5)"),
-                    summary: tool.schema
-                        .string()
-                        .describe("Complete technical summary replacing all content in range"),
-                }),
-            )
-            .describe(
-                "One or more ranges to compress, each with start/end boundaries and a summary",
-            ),
-    }
-}
-
-export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof tool> {
+export function createCompressRangeTool(ctx: ToolContext) {
     ctx.prompts.reload()
     const runtimePrompts = ctx.prompts.getRuntimePrompts()
 
-    return tool({
+    return {
         description: runtimePrompts.compressRange + RANGE_FORMAT_EXTENSION,
-        args: buildSchema(),
-        async execute(args, toolCtx) {
+        async execute(args: CompressRangeToolArgs, toolCtx: any) {
             const input = args as CompressRangeToolArgs
             validateArgs(input)
             const callId =
@@ -188,5 +159,5 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
 
             return `Compressed ${totalCompressedMessages} messages into ${COMPRESSED_BLOCK_HEADER}.`
         },
-    })
+    }
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,7 +1,8 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync } from "fs"
 import { join, dirname } from "path"
 import { homedir } from "os"
-import { parse } from "jsonc-parser/lib/esm/main.js"
+import * as jsonc from "jsonc-parser"
+const parse = jsonc.parse
 import type { PluginInput } from "@opencode-ai/plugin"
 
 type Permission = "ask" | "allow" | "deny"

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -46,6 +46,47 @@ const INTERNAL_AGENT_SIGNATURES = [
     "Summarize what was done in this conversation",
 ]
 
+// Caches provider/model -> context window size resolved via `client.model.list()`.
+// The v2 `session.hook("context")` event only carries a `Model.Ref`
+// (id/providerID/variant), never the full `Model.Info.limit.context` that v1's
+// chat hooks received directly, so percentage-based `maxContextLimit`/
+// `minContextLimit` configs need this looked up out-of-band at least once per
+// provider/model pair.
+const modelContextLimitCache = new Map<string, number>()
+
+export async function resolveModelContextLimit(
+    client: any,
+    providerID: string | undefined,
+    modelID: string | undefined,
+): Promise<number | undefined> {
+    if (!providerID || !modelID || typeof client?.model?.list !== "function") {
+        return undefined
+    }
+
+    const cacheKey = `${providerID}/${modelID}`
+    const cached = modelContextLimitCache.get(cacheKey)
+    if (cached !== undefined) {
+        return cached
+    }
+
+    try {
+        const response = await client.model.list()
+        const models = (response?.data ?? response ?? []) as any[]
+        for (const model of models) {
+            const context = model?.limit?.context
+            if (typeof context !== "number") {
+                continue
+            }
+            const key = `${model.providerID}/${model.modelID ?? model.id}`
+            modelContextLimitCache.set(key, context)
+        }
+    } catch {
+        return undefined
+    }
+
+    return modelContextLimitCache.get(cacheKey)
+}
+
 export function createSystemPromptHandler(
     state: SessionState,
     logger: Logger,
@@ -133,6 +174,18 @@ export function createContextHandler(
         if (event.model?.limit?.context) {
             state.modelContextLimit = event.model.limit.context
             logger.debug("Cached model context limit", { limit: state.modelContextLimit })
+        } else if (state.modelContextLimit === undefined) {
+            const resolved = await resolveModelContextLimit(
+                client,
+                event.model?.providerID,
+                event.model?.id,
+            )
+            if (resolved !== undefined) {
+                state.modelContextLimit = resolved
+                logger.debug("Resolved model context limit via model catalog", {
+                    limit: resolved,
+                })
+            }
         }
 
         if (event.system && Array.isArray(event.system)) {
@@ -142,10 +195,7 @@ export function createContextHandler(
                     typeof s === "string" ? s : (s?.text ?? ""),
                 )
                 const tempOutput = { system: stringArray }
-                await systemHandler(
-                    { sessionID: event.sessionID, model: event.model },
-                    tempOutput,
-                )
+                await systemHandler({ sessionID: event.sessionID, model: event.model }, tempOutput)
                 if (tempOutput.system.length > stringArray.length) {
                     for (let i = stringArray.length; i < tempOutput.system.length; i++) {
                         event.system.push({ type: "text", text: tempOutput.system[i] })

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -82,6 +82,12 @@ export function createSystemPromptHandler(
 
         prompts.reload()
         const runtimePrompts = prompts.getRuntimePrompts()
+        const baseSystemPrompt = runtimePrompts.system.trim()
+        if (baseSystemPrompt && systemText.includes(baseSystemPrompt)) {
+            logger.info("Skipping DCP system prompt injection (already present in system prompt)")
+            return
+        }
+
         const newPrompt = renderSystemPrompt(
             runtimePrompts,
             buildProtectedToolsExtension(config.compress.protectedTools),
@@ -92,6 +98,183 @@ export function createSystemPromptHandler(
             output.system[output.system.length - 1] += "\n\n" + newPrompt
         } else {
             output.system.push(newPrompt)
+        }
+    }
+}
+
+export interface ContextHookEvent {
+    sessionID?: string
+    agent?: string
+    model?: any
+    system?: any[]
+    messages?: WithParts[]
+    tools?: Record<string, any>
+}
+
+export function createContextHandler(
+    client: any,
+    state: SessionState,
+    logger: Logger,
+    config: PluginConfig,
+    prompts: PromptStore,
+    hostPermissions: HostPermissionSnapshot,
+) {
+    const systemHandler = createSystemPromptHandler(state, logger, config, prompts)
+    const chatHandler = createChatMessageTransformHandler(
+        client,
+        state,
+        logger,
+        config,
+        prompts,
+        hostPermissions,
+    )
+
+    return async (event: ContextHookEvent) => {
+        if (event.model?.limit?.context) {
+            state.modelContextLimit = event.model.limit.context
+            logger.debug("Cached model context limit", { limit: state.modelContextLimit })
+        }
+
+        if (event.system && Array.isArray(event.system)) {
+            const isObjectSystem = event.system.length > 0 && typeof event.system[0] === "object"
+            if (isObjectSystem) {
+                const stringArray = event.system.map((s: any) =>
+                    typeof s === "string" ? s : (s?.text ?? ""),
+                )
+                const tempOutput = { system: stringArray }
+                await systemHandler(
+                    { sessionID: event.sessionID, model: event.model },
+                    tempOutput,
+                )
+                if (tempOutput.system.length > stringArray.length) {
+                    for (let i = stringArray.length; i < tempOutput.system.length; i++) {
+                        event.system.push({ type: "text", text: tempOutput.system[i] })
+                    }
+                }
+                if (tempOutput.system.length > 0 && event.system.length > 0) {
+                    const lastTemp = tempOutput.system[stringArray.length - 1]
+                    const origLast = stringArray[stringArray.length - 1]
+                    if (lastTemp !== origLast) {
+                        const target = event.system[stringArray.length - 1]
+                        if (typeof target === "string") {
+                            event.system[stringArray.length - 1] = lastTemp
+                        } else if (target && typeof target === "object") {
+                            target.text = lastTemp
+                        }
+                    }
+                }
+            } else {
+                const tempOutput = { system: event.system }
+                await systemHandler(
+                    { sessionID: event.sessionID, model: event.model },
+                    tempOutput as any,
+                )
+            }
+        }
+
+        if (event.messages && Array.isArray(event.messages)) {
+            const v2Meta = new Map<
+                any,
+                {
+                    wasArray: boolean
+                    originalContent: any
+                    hadSyntheticInfo: boolean
+                    hadSyntheticParts: boolean
+                }
+            >()
+            for (let i = 0; i < event.messages.length; i++) {
+                const msg = event.messages[i] as any
+                if (!msg || typeof msg !== "object") continue
+
+                const wasArray = Array.isArray(msg.content)
+                const hadSyntheticInfo = !msg.info || typeof msg.info !== "object"
+                const hadSyntheticParts = !Array.isArray(msg.parts)
+
+                v2Meta.set(msg, {
+                    wasArray,
+                    originalContent: msg.content,
+                    hadSyntheticInfo,
+                    hadSyntheticParts,
+                })
+
+                if (hadSyntheticInfo) {
+                    msg.info = {
+                        id: msg.id ?? `m${i.toString().padStart(4, "0")}`,
+                        sessionID: event.sessionID ?? state.sessionId ?? "default",
+                        role: msg.role ?? "user",
+                        time: { created: Date.now() - (event.messages.length - i) * 1000 },
+                    }
+                }
+                if (hadSyntheticParts) {
+                    if (Array.isArray(msg.content)) {
+                        msg.parts = msg.content
+                    } else if (msg.role === "tool" || msg.tool_call_id) {
+                        msg.parts = [
+                            {
+                                type: "tool",
+                                callID: msg.tool_call_id ?? msg.id ?? `call_${i}`,
+                                state: {
+                                    status: "completed",
+                                    output:
+                                        typeof msg.content === "string"
+                                            ? msg.content
+                                            : JSON.stringify(msg.content ?? ""),
+                                },
+                            },
+                        ]
+                    } else if (msg.role === "assistant" && Array.isArray(msg.tool_calls)) {
+                        msg.parts = []
+                        if (typeof msg.content === "string" && msg.content.length > 0) {
+                            msg.parts.push({ type: "text", text: msg.content })
+                        }
+                        for (const tc of msg.tool_calls) {
+                            msg.parts.push({
+                                type: "tool",
+                                tool: tc.function?.name ?? tc.name ?? "unknown",
+                                callID: tc.id,
+                                state: {
+                                    status: "running",
+                                    input: tc.function?.arguments ?? tc.arguments,
+                                },
+                            })
+                        }
+                    } else if (typeof msg.content === "string") {
+                        msg.parts = [{ type: "text", text: msg.content }]
+                    } else {
+                        msg.parts = []
+                    }
+                }
+            }
+
+            await chatHandler({ sessionID: event.sessionID }, { messages: event.messages })
+
+            for (const [msg, meta] of v2Meta.entries()) {
+                if (!msg) continue
+                if (meta.wasArray) {
+                    msg.content = msg.parts
+                } else if (typeof meta.originalContent === "string") {
+                    const textParts = (msg.parts || [])
+                        .filter((p: any) => p.type === "text")
+                        .map((p: any) => p.text ?? "")
+                    if (textParts.length > 0) {
+                        msg.content = textParts.join("\n")
+                    } else if (msg.role === "tool") {
+                        const toolPart = (msg.parts || []).find((p: any) => p.type === "tool")
+                        if (toolPart?.state?.output !== undefined) {
+                            msg.content =
+                                typeof toolPart.state.output === "string"
+                                    ? toolPart.state.output
+                                    : JSON.stringify(toolPart.state.output)
+                        }
+                    }
+                }
+                if (meta.hadSyntheticInfo) {
+                    delete msg.info
+                }
+                if (meta.hadSyntheticParts && !meta.wasArray) {
+                    delete msg.parts
+                }
+            }
         }
     }
 }

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -38,6 +38,7 @@ import { type HostPermissionSnapshot } from "./host-permissions"
 import { compressPermission, syncCompressPermissionState } from "./compress-permission"
 import { checkSession, ensureSessionInitialized, saveSessionState, syncToolCache } from "./state"
 import { cacheSystemPromptTokens } from "./ui/utils"
+import { setLastKnownMessages } from "./state/message-cache"
 
 const INTERNAL_AGENT_SIGNATURES = [
     "You are a title generator",
@@ -337,7 +338,7 @@ export function createChatMessageTransformHandler(
     prompts: PromptStore,
     hostPermissions: HostPermissionSnapshot,
 ) {
-    return async (input: {}, output: { messages: WithParts[] }) => {
+    return async (input: { sessionID?: string }, output: { messages: WithParts[] }) => {
         const receivedMessages = Array.isArray(output.messages) ? output.messages.length : 0
         const messages = filterMessagesInPlace(output.messages)
         if (messages.length !== receivedMessages) {
@@ -358,6 +359,27 @@ export function createChatMessageTransformHandler(
         stripHallucinations(output.messages)
         cacheSystemPromptTokens(state, output.messages)
         assignMessageRefs(state, output.messages)
+
+        // v2 plugins have no way to fetch a session's message history on
+        // demand (see lib/v2-client-shim.ts) -- the only place the full,
+        // live message list is ever handed to this plugin is right here, on
+        // every context-hook turn. Cache it (pre-pruning, matching what v1's
+        // client.session.messages() returned: raw session content, not this
+        // turn's in-flight redactions) so the compress tool and subagent
+        // output expansion can read it back instead of crashing.
+        setLastKnownMessages(
+            input.sessionID ?? state.sessionId,
+            output.messages.map((m) =>
+                m && typeof m === "object"
+                    ? {
+                          ...m,
+                          parts: Array.isArray((m as any).parts)
+                              ? [...(m as any).parts]
+                              : (m as any).parts,
+                      }
+                    : m,
+            ),
+        )
         syncCompressionBlocks(state, logger, output.messages)
         syncToolCache(state, config, logger, output.messages)
         buildToolIdList(state, output.messages)

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -77,10 +77,10 @@ export function getModelInfo(messages: WithParts[]): LastUserModelContext {
         }
     }
 
-    const userInfo = lastUserMessage.info as UserMessage
+    const userInfo = lastUserMessage.info as any
     return {
-        providerId: userInfo.model.providerID,
-        modelId: userInfo.model.modelID,
+        providerId: userInfo?.model?.providerID,
+        modelId: userInfo?.model?.modelID,
     }
 }
 

--- a/lib/messages/reasoning-strip.ts
+++ b/lib/messages/reasoning-strip.ts
@@ -12,8 +12,9 @@ export function stripStaleMetadata(messages: WithParts[]): void {
         return
     }
 
-    const modelID = lastUserMessage.info.model.modelID
-    const providerID = lastUserMessage.info.model.providerID
+    const model = (lastUserMessage.info as any)?.model
+    const modelID = model?.modelID
+    const providerID = model?.providerID
 
     messages.forEach((message) => {
         if (message.info.role !== "assistant") {

--- a/lib/messages/shape.ts
+++ b/lib/messages/shape.ts
@@ -14,12 +14,10 @@ export function isMessageWithInfo(message: unknown): message is WithParts {
     return (
         typeof info.id === "string" &&
         info.id.length > 0 &&
-        typeof info.sessionID === "string" &&
-        info.sessionID.length > 0 &&
-        (info.role === "user" || info.role === "assistant") &&
-        info.time &&
-        typeof info.time === "object" &&
-        typeof info.time.created === "number" &&
+        (info.role === "user" ||
+            info.role === "assistant" ||
+            info.role === "system" ||
+            info.role === "tool") &&
         Array.isArray(parts)
     )
 }

--- a/lib/state/message-cache.ts
+++ b/lib/state/message-cache.ts
@@ -1,0 +1,42 @@
+// v2's plugin `Context` does not expose session message history to plugins at
+// all: `ctx.session` only picks `create | get | prompt | generate | command |
+// synthetic | interrupt | hook` off the full `SessionApi` (confirmed against
+// @opencode-ai/plugin's promise/session.d.ts) -- `.messages`/`.export` are not
+// among them, and there is no separate `ctx.message` domain on `Context`
+// either, even though `MessageApi.list({sessionID})` exists on the full
+// client. The only place a v2 plugin legitimately sees message content is the
+// `messages` array handed to it live inside `ctx.session.hook("context", ...)`.
+//
+// This module lets `createChatMessageTransformHandler` (which runs on every
+// context-hook turn, for every session including subagent sub-sessions) stash
+// the messages it was given, keyed by session ID, so anything that needs a
+// session's message history later in the same process (the compress tool,
+// subagent output expansion) can read it back instead of calling a client
+// method that doesn't exist under v2. Under v1, this cache is unused --
+// `fetchSessionMessages`/`fetchSubAgentMessages` call the real
+// `client.session.messages(...)` first and only fall back to this cache when
+// that capability is unavailable.
+
+const cache = new Map<string, unknown[]>()
+
+export function setLastKnownMessages(
+    sessionID: string | undefined | null,
+    messages: unknown[],
+): void {
+    if (!sessionID || !Array.isArray(messages)) {
+        return
+    }
+    cache.set(sessionID, messages)
+}
+
+export function getLastKnownMessages(sessionID: string | undefined | null): unknown[] | undefined {
+    if (!sessionID) {
+        return undefined
+    }
+    return cache.get(sessionID)
+}
+
+/** Test-only: reset cache state between test files. */
+export function clearMessageCache(): void {
+    cache.clear()
+}

--- a/lib/token-utils.ts
+++ b/lib/token-utils.ts
@@ -85,9 +85,15 @@ export function getCurrentParams(
     }
     const userInfo = userMsg.info as UserMessage
     const agent: string = userInfo.agent
-    const providerId: string | undefined = userInfo.model.providerID
-    const modelId: string | undefined = userInfo.model.modelID
-    const variant: string | undefined = userInfo.model.variant
+    // v1's UserMessage.info always carried `.model` (a real SessionMessage).
+    // v2's context hook fabricates synthetic `.info` for native AI SDK
+    // messages ({id, sessionID, role, time} only, in hooks.ts's
+    // createContextHandler) -- it never sets `.model`. Guard rather than
+    // crash finalizeSession (and lose an already-applied compression) when
+    // it's absent.
+    const providerId: string | undefined = userInfo.model?.providerID
+    const modelId: string | undefined = userInfo.model?.modelID
+    const variant: string | undefined = userInfo.model?.variant
 
     return { providerId, modelId, agent, variant }
 }

--- a/lib/token-utils.ts
+++ b/lib/token-utils.ts
@@ -14,7 +14,18 @@ export function getCurrentTokenUsage(state: SessionState, messages: WithParts[])
         }
 
         const assistantInfo = msg.info as AssistantMessage
-        if ((assistantInfo.tokens?.output || 0) <= 0) {
+        const rawTokens = (assistantInfo as any).tokens
+        if (rawTokens === undefined) {
+            // The v2 `session.hook("context")` event adapts native LLM-request
+            // messages (`@opencode-ai/ai` Message: id/role/content only) into
+            // this shape. Unlike a real SessionMessage.AssistantMessage,
+            // `tokens` is never attached to those synthetic entries, so no
+            // host-reported usage will ever be found by scanning further back.
+            // Fall back to a local estimate instead of silently reporting 0.
+            break
+        }
+
+        if ((rawTokens.output || 0) <= 0) {
             continue
         }
 
@@ -26,15 +37,30 @@ export function getCurrentTokenUsage(state: SessionState, messages: WithParts[])
             return 0
         }
 
-        const input = assistantInfo.tokens?.input || 0
-        const output = assistantInfo.tokens?.output || 0
-        const reasoning = assistantInfo.tokens?.reasoning || 0
-        const cacheRead = assistantInfo.tokens?.cache?.read || 0
-        const cacheWrite = assistantInfo.tokens?.cache?.write || 0
+        const input = rawTokens.input || 0
+        const output = rawTokens.output || 0
+        const reasoning = rawTokens.reasoning || 0
+        const cacheRead = rawTokens.cache?.read || 0
+        const cacheWrite = rawTokens.cache?.write || 0
         return input + output + reasoning + cacheRead + cacheWrite
     }
 
-    return 0
+    return estimateCurrentTokenUsage(messages)
+}
+
+/**
+ * Local fallback for contexts where the host never attaches token usage
+ * stats to messages (see `getCurrentTokenUsage`). Estimates the live context
+ * size from the message content actually present in `messages`, which by the
+ * time this runs already reflects pruning/compression applied earlier in the
+ * pipeline.
+ */
+function estimateCurrentTokenUsage(messages: WithParts[]): number {
+    let total = 0
+    for (const msg of messages) {
+        total += countAllMessageTokens(msg)
+    }
+    return total
 }
 
 export function getCurrentParams(

--- a/lib/ui/notification.ts
+++ b/lib/ui/notification.ts
@@ -120,14 +120,24 @@ export async function sendUnifiedNotification(
         toastMessage =
             config.pruneNotification === "minimal" ? toastMessage : truncateToastBody(toastMessage)
 
-        await client.tui.showToast({
-            body: {
-                title: "DCP: Compress Notification",
-                message: toastMessage,
-                variant: "info",
-                duration: 5000,
-            },
-        })
+        if (typeof client?.tui?.showToast !== "function") {
+            logger.debug("Toast notifications are not available on this host; skipping")
+            return false
+        }
+
+        try {
+            await client.tui.showToast({
+                body: {
+                    title: "DCP: Compress Notification",
+                    message: toastMessage,
+                    variant: "info",
+                    duration: 5000,
+                },
+            })
+        } catch (error: any) {
+            logger.warn("Failed to show toast notification", { error: error?.message })
+            return false
+        }
         return true
     }
 
@@ -290,14 +300,24 @@ export async function sendCompressNotification(
         toastMessage =
             config.pruneNotification === "minimal" ? toastMessage : truncateToastBody(toastMessage)
 
-        await client.tui.showToast({
-            body: {
-                title: "DCP: Compress Notification",
-                message: toastMessage,
-                variant: "info",
-                duration: 5000,
-            },
-        })
+        if (typeof client?.tui?.showToast !== "function") {
+            logger.debug("Toast notifications are not available on this host; skipping")
+            return false
+        }
+
+        try {
+            await client.tui.showToast({
+                body: {
+                    title: "DCP: Compress Notification",
+                    message: toastMessage,
+                    variant: "info",
+                    duration: 5000,
+                },
+            })
+        } catch (error: any) {
+            logger.warn("Failed to show toast notification", { error: error?.message })
+            return false
+        }
         return true
     }
 

--- a/lib/update.ts
+++ b/lib/update.ts
@@ -25,6 +25,10 @@ export function startAutoUpdate(ctx: PluginInput, enabled: boolean): void {
         .then((result) => {
             if (!result.updated) return
             setTimeout(() => {
+                // v2's plugin ctx has no toast/TUI domain at all -- guard
+                // rather than crash inside this bare setTimeout callback
+                // (which no surrounding try/catch protects).
+                if (typeof ctx.client?.tui?.showToast !== "function") return
                 ctx.client.tui.showToast({
                     body: {
                         title: "DCP update ready",

--- a/lib/v2-client-shim.ts
+++ b/lib/v2-client-shim.ts
@@ -1,0 +1,63 @@
+// index.ts's v2 `setup(ctx)` used to do `const client = ctx?.client` and hand
+// that straight to every lib/*.ts function that was written against v1's rich
+// client (client.session.messages, client.session.get, client.model.list,
+// client.tui.showToast, client.session.prompt). In v2's beta plugin API,
+// `ctx.client` does not exist at all -- confirmed against the installed
+// @opencode-ai/plugin Context type (app/options/agent/aisdk/catalog/command/
+// event/integration/plugin/reference/session/shell/skill/tool/websearch, no
+// `client` field) -- so that variable was `undefined` for the lifetime of
+// every v2 process, and every call site crashed or silently no-op'd the first
+// time it was actually exercised.
+//
+// This shim translates the small number of v1-shaped calls the rest of the
+// codebase already makes into the real v2 `ctx` domain calls, so lib/*.ts
+// does not need to change call shapes at every site. Where v2 genuinely has
+// no equivalent capability (session message history, toast notifications,
+// an "ignored, no-reply" chat message), the shim degrades to a cache lookup
+// or a clearly-labelled thrown error that existing callers already catch and
+// log, rather than crashing with an opaque `undefined is not an object`.
+import { getLastKnownMessages } from "./state/message-cache"
+
+export function buildV2ClientCompat(ctx: any) {
+    return {
+        model: {
+            async list() {
+                const response = await ctx.catalog.model.list()
+                return { data: response?.data ?? [] }
+            },
+        },
+        session: {
+            async get(input: { path?: { id?: string }; sessionID?: string }) {
+                const sessionID = input?.path?.id ?? input?.sessionID
+                const info = await ctx.session.get({ sessionID })
+                return { data: info }
+            },
+            async messages(input: { path?: { id?: string }; sessionID?: string }) {
+                const sessionID = input?.path?.id ?? input?.sessionID
+                const cached = getLastKnownMessages(sessionID)
+                if (!cached) {
+                    throw new Error(
+                        `Session message history for ${sessionID} is unavailable: the v2 plugin API does not expose session message history to plugins (ctx.session omits messages/export, and there is no ctx.message domain), and no context-hook turn has been observed yet for this session.`,
+                    )
+                }
+                return { data: cached }
+            },
+            async prompt() {
+                // v1's client.session.prompt supported `noReply` + a part-level
+                // `ignored` flag to post a silent, non-conversational chat
+                // notification. v2's real session.prompt input
+                // (sessionID/id/text/files/agents/skills/metadata/delivery/resume)
+                // has no equivalent -- calling it would send a real, visible
+                // message and solicit an actual model turn. Callers
+                // (sendIgnoredMessage) already catch and log this.
+                throw new Error(
+                    'session.prompt-based chat notifications are not supported by the v2 plugin API (no "ignored"/"no-reply" equivalent); set pruneNotificationType to something other than "chat", or accept that notifications are skipped.',
+                )
+            },
+        },
+        // Deliberately no `.tui`: v2's Context has no toast/TUI domain for
+        // plugins at all. Its absence is the signal every `client.tui...`
+        // call site checks (`typeof client?.tui?.showToast === "function"`)
+        // to degrade to a log instead of crashing.
+    }
+}

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
+            "import": "./dist/index.js",
+            "default": "./dist/index.js"
         },
         "./server": {
             "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
+            "import": "./dist/index.js",
+            "default": "./dist/index.js"
         },
         "./tui": {
             "types": "./dist/tui.d.ts",
@@ -60,11 +62,11 @@
     },
     "dependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",
-        "@opencode-ai/sdk": "^1.4.3",
+        "@opencode-ai/plugin": "1.18.4",
+        "@opencode-ai/sdk": "^1.18.4",
         "jsonc-parser": "^3.3.1"
     },
     "devDependencies": {
-        "@opencode-ai/plugin": "^1.4.3",
         "@opentui/core": "^0.4.2",
         "@opentui/solid": "^0.4.2",
         "@types/node": "^25.5.0",

--- a/tests/compress-range.test.ts
+++ b/tests/compress-range.test.ts
@@ -179,6 +179,59 @@ test("compress range rebuilds subagent message refs after session state was rese
     assert.equal(state.prune.messages.blocksById.size, 1)
 })
 
+// Regression coverage: every other test in this file (and every other
+// compress-tool test in the suite) mocks toolCtx with v1's ask()/metadata(),
+// which is why the real v2 Tool.Context shape (@opencode-ai/plugin promise
+// and effect tool.d.ts: sessionID/agent/messageID/id/progress only -- no
+// ask, no metadata) crashed every compress execution under v2 with an
+// opaque failure and no test ever caught it. This models the real v2 shape.
+test("compress range mode runs under the real v2 tool context (no ask/metadata)", async () => {
+    const sessionID = `ses_range_v2_context_${Date.now()}`
+    const rawMessages = buildMessages(sessionID)
+    const state = createSessionState()
+    const logger = new Logger(false)
+    const tool = createCompressRangeTool({
+        client: {
+            session: {
+                messages: async () => ({ data: rawMessages }),
+                get: async () => ({ data: { parentID: "ses_parent" } }),
+            },
+        },
+        state,
+        logger,
+        config: buildConfig(),
+        prompts: {
+            reload() {},
+            getRuntimePrompts() {
+                return { compressRange: "", compressMessage: "" }
+            },
+        },
+    } as any)
+
+    const result = await tool.execute(
+        {
+            topic: "v2 context shape",
+            content: [
+                {
+                    startId: "m0001",
+                    endId: "m0002",
+                    summary: "Captured the initial investigation and follow-up request.",
+                },
+            ],
+        },
+        {
+            sessionID,
+            agent: "assistant",
+            messageID: "msg-compress-v2",
+            id: "call-compress-v2",
+            progress: async () => {},
+        },
+    )
+
+    assert.equal(result, "Compressed 2 messages into [Compressed conversation section].")
+    assert.equal(state.prune.messages.blocksById.size, 1)
+})
+
 test("compress range mode appends protected prompt info", async () => {
     const sessionID = `ses_range_protect_tag_${Date.now()}`
     const rawMessages: WithParts[] = [

--- a/tests/model-context-limit.test.ts
+++ b/tests/model-context-limit.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { resolveModelContextLimit } from "../lib/hooks"
+
+// The v2 `session.hook("context")` event only carries a `Model.Ref`
+// (id/providerID/variant) on `event.model` -- never the full `Model.Info`
+// with `limit.context` that v1's chat hooks received directly. Percentage
+// based `compress.maxContextLimit`/`minContextLimit` configs need this
+// resolved out-of-band via `client.model.list()`.
+
+test("resolveModelContextLimit resolves context window from client.model.list()", async () => {
+    const client = {
+        model: {
+            list: async () => ({
+                data: [
+                    {
+                        id: "grok-4.6",
+                        modelID: "grok-4.6",
+                        providerID: "xai",
+                        limit: { context: 256_000, output: 8_000 },
+                    },
+                ],
+            }),
+        },
+    }
+
+    const limit = await resolveModelContextLimit(client, "xai", "grok-4.6")
+    assert.equal(limit, 256_000)
+})
+
+test("resolveModelContextLimit caches by provider/model across calls", async () => {
+    let callCount = 0
+    const client = {
+        model: {
+            list: async () => {
+                callCount += 1
+                return {
+                    data: [
+                        {
+                            id: "cache-test-model",
+                            modelID: "cache-test-model",
+                            providerID: "cache-test-provider",
+                            limit: { context: 128_000, output: 4_000 },
+                        },
+                    ],
+                }
+            },
+        },
+    }
+
+    const first = await resolveModelContextLimit(client, "cache-test-provider", "cache-test-model")
+    const second = await resolveModelContextLimit(client, "cache-test-provider", "cache-test-model")
+
+    assert.equal(first, 128_000)
+    assert.equal(second, 128_000)
+    assert.equal(callCount, 1)
+})
+
+test("resolveModelContextLimit returns undefined without a usable client", async () => {
+    assert.equal(await resolveModelContextLimit(undefined, "xai", "grok-4.6"), undefined)
+    assert.equal(await resolveModelContextLimit({}, "xai", "grok-4.6"), undefined)
+    assert.equal(await resolveModelContextLimit({ model: {} }, "xai", "grok-4.6"), undefined)
+})
+
+test("resolveModelContextLimit returns undefined when provider or model id is missing", async () => {
+    const client = { model: { list: async () => ({ data: [] }) } }
+    assert.equal(await resolveModelContextLimit(client, undefined, "grok-4.6"), undefined)
+    assert.equal(await resolveModelContextLimit(client, "xai", undefined), undefined)
+})
+
+test("resolveModelContextLimit swallows client errors", async () => {
+    const client = {
+        model: {
+            list: async () => {
+                throw new Error("network down")
+            },
+        },
+    }
+
+    const limit = await resolveModelContextLimit(
+        client,
+        "unreachable-provider",
+        "unreachable-model",
+    )
+    assert.equal(limit, undefined)
+})

--- a/tests/token-usage.test.ts
+++ b/tests/token-usage.test.ts
@@ -210,6 +210,75 @@ test("getCurrentTokenUsage returns 0 until a fresh assistant follows compaction"
     assert.equal(getCurrentTokenUsage(state, messages), 0)
 })
 
+// Regression coverage for the v2 port: `session.hook("context")` adapts
+// native LLM-request messages (`@opencode-ai/ai` Message: id/role/content
+// only) into the `WithParts` shape this plugin operates on, and never
+// attaches `.tokens` to the synthetic `info` it fabricates -- unlike a real
+// SessionMessage.AssistantMessage, where `tokens` is a required field. Before
+// this fix, `getCurrentTokenUsage` silently returned 0 for every v2 turn,
+// so `isContextOverLimits`/`injectCompressNudges` never fired no matter how
+// large the context grew.
+function buildNativeV2Messages(): WithParts[] {
+    const sessionID = "ses_v2_native"
+
+    return [
+        {
+            info: {
+                id: "m0001",
+                role: "user",
+                sessionID,
+                agent: "assistant",
+                time: { created: 1 },
+            } as WithParts["info"],
+            parts: [textPart("m0001", sessionID, "m0001-part", repeatedWord("investigate", 50))],
+        },
+        {
+            info: {
+                // No `tokens` field: the host never reports usage on native
+                // v2 context-hook messages.
+                id: "m0002",
+                role: "assistant",
+                sessionID,
+                agent: "assistant",
+                time: { created: 2 },
+            } as WithParts["info"],
+            parts: [textPart("m0002", sessionID, "m0002-part", repeatedWord("finding", 400))],
+        },
+    ]
+}
+
+test("getCurrentTokenUsage estimates from content when the host never reports usage (v2 native messages)", () => {
+    const state = createSessionState()
+    const messages = buildNativeV2Messages()
+
+    const usage = getCurrentTokenUsage(state, messages)
+    assert.ok(usage > 0, `expected a positive local estimate for v2 native messages, got ${usage}`)
+})
+
+test("isContextOverLimits fires for v2 native messages once the estimate crosses maxContextLimit", () => {
+    const state = createSessionState()
+    const messages = buildNativeV2Messages()
+    const usage = getCurrentTokenUsage(state, messages)
+
+    const stillUnder = isContextOverLimits(
+        buildConfig(usage + 1, 1),
+        state,
+        undefined,
+        undefined,
+        messages,
+    )
+    assert.equal(stillUnder.overMaxLimit, false)
+
+    const nowOver = isContextOverLimits(
+        buildConfig(usage - 1, 1),
+        state,
+        undefined,
+        undefined,
+        messages,
+    )
+    assert.equal(nowOver.overMaxLimit, true)
+})
+
 test("isContextOverLimits ignores stale summary totals and resumes with fresh reported totals", () => {
     const messages = buildCompactedMessages()
     const state = createSessionState()

--- a/tests/v2-plugin.test.ts
+++ b/tests/v2-plugin.test.ts
@@ -1,0 +1,431 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import plugin from "../index"
+import type { WithParts } from "../lib/state"
+
+function fakeContext() {
+    const hooks = new Map<string, (event: any) => Promise<void>>()
+    const tools = new Map<string, any>()
+    const commands = new Map<string, any>()
+    const events: Array<(event: any) => Promise<void>> = []
+    const disposed: string[] = []
+
+    const createRegistration = (name: string) => ({
+        dispose: async () => {
+            disposed.push(name)
+        },
+    })
+
+    const messagesStore: WithParts[] = []
+
+    const value = {
+        app: {
+            name: "opencode",
+            version: "2",
+            channel: "test",
+            workspace: { directory: process.cwd() },
+        },
+        directory: process.cwd(),
+        client: {
+            session: {
+                get: async () => ({ id: "session-v2", isSubAgent: false }),
+                messages: async () => ({ data: messagesStore }),
+            },
+            tui: {
+                showToast: async () => undefined,
+            },
+        },
+        session: {
+            hook: async (name: string, callback: (event: any) => Promise<void>) => {
+                hooks.set(name, callback)
+                return createRegistration(`session.hook:${name}`)
+            },
+        },
+        tool: {
+            transform: async (callback: (draft: any) => void) => {
+                callback({
+                    add: (toolDef: any) => {
+                        tools.set(toolDef.name, toolDef)
+                    },
+                })
+                return createRegistration("tool.transform")
+            },
+        },
+        command: {
+            transform: async (callback: (draft: any) => void) => {
+                callback({
+                    update: (id: string | any, updater?: any) => {
+                        if (typeof id === "object") {
+                            commands.set(id.name, id)
+                            return
+                        }
+                        const entry: any = { name: id, template: "", description: "" }
+                        if (typeof updater === "function") {
+                            updater(entry)
+                        } else if (updater && typeof updater === "object") {
+                            Object.assign(entry, updater)
+                        }
+                        commands.set(id, entry)
+                    },
+                    add: (entry: any) => {
+                        commands.set(entry.name, entry)
+                    },
+                })
+                return createRegistration("command.transform")
+            },
+        },
+        event: {
+            subscribe: async (callback: (event: any) => Promise<void>) => {
+                events.push(callback)
+                return createRegistration("event.subscribe")
+            },
+        },
+    }
+
+    return {
+        value,
+        hooks,
+        tools,
+        commands,
+        events,
+        disposed,
+        messagesStore,
+    }
+}
+
+function buildToolMessage(id: string, toolName: string, callID: string, output: string): WithParts {
+    return {
+        info: {
+            id,
+            role: "assistant",
+            sessionID: "session-v2",
+            agent: "assistant",
+            time: { created: 1000 },
+        } as WithParts["info"],
+        parts: [
+            {
+                id: `${id}-tool-part`,
+                messageID: id,
+                sessionID: "session-v2",
+                type: "tool",
+                tool: toolName,
+                callID,
+                state: {
+                    status: "completed",
+                    input: { path: "src/main.ts" },
+                    output,
+                },
+            } as any,
+        ],
+    }
+}
+
+function buildUserMessage(id: string, text: string): WithParts {
+    return {
+        info: {
+            id,
+            role: "user",
+            sessionID: "session-v2",
+            agent: "user",
+            time: { created: 500 },
+        } as WithParts["info"],
+        parts: [
+            {
+                id: `${id}-text-part`,
+                messageID: id,
+                sessionID: "session-v2",
+                type: "text",
+                text,
+            } as any,
+        ],
+    }
+}
+
+test("OpenCode v2 plugin export shape", () => {
+    assert.equal(typeof plugin, "object")
+    assert.equal(plugin.id, "opencode-dcp")
+    assert.equal(typeof plugin.setup, "function")
+})
+
+test("setup registers context hook, compress tool, and dcp-compress command", async () => {
+    const fake = fakeContext()
+    const cleanup = await plugin.setup(fake.value)
+
+    assert.equal(typeof cleanup, "function")
+    assert.equal(fake.hooks.has("context"), true)
+    assert.equal(fake.tools.has("compress"), true)
+    assert.equal(fake.commands.has("dcp-compress"), true)
+    assert.equal(fake.events.length > 0, true)
+
+    const compressTool = fake.tools.get("compress")
+    assert.equal(compressTool.name, "compress")
+    assert.equal(typeof compressTool.description, "string")
+    assert.equal(typeof compressTool.execute, "function")
+    assert.equal(compressTool.input?.type, "object")
+
+    const dcpCommand = fake.commands.get("dcp-compress")
+    assert.equal(dcpCommand.name, "dcp-compress")
+    assert.ok(dcpCommand.description.includes("dcp-compress"))
+
+    await cleanup()
+    assert.ok(fake.disposed.includes("session.hook:context"))
+    assert.ok(fake.disposed.includes("tool.transform"))
+    assert.ok(fake.disposed.includes("command.transform"))
+    assert.ok(fake.disposed.includes("event.subscribe"))
+})
+
+test("context hook updates model context limit and injects system prompt instructions", async () => {
+    const fake = fakeContext()
+    const cleanup = await plugin.setup(fake.value)
+
+    const contextHook = fake.hooks.get("context")!
+    assert.ok(contextHook)
+
+    const event = {
+        sessionID: "session-v2",
+        agent: "general",
+        model: {
+            id: "claude-sonnet-4-6",
+            providerID: "anthropic",
+            limit: { context: 200_000 },
+        },
+        system: ["You are a coding assistant."],
+        messages: [],
+        tools: {},
+    }
+
+    await contextHook(event)
+
+    assert.ok(event.system.length > 0)
+    const combinedSystem = event.system.join("\n")
+    assert.ok(
+        combinedSystem.includes("Dynamic Context Pruning") ||
+            combinedSystem.includes("dcp") ||
+            combinedSystem.includes("compress"),
+    )
+
+    await cleanup()
+})
+
+test("context hook skips injection for internal agents", async () => {
+    const fake = fakeContext()
+    const cleanup = await plugin.setup(fake.value)
+
+    const contextHook = fake.hooks.get("context")!
+    assert.ok(contextHook)
+
+    const event = {
+        sessionID: "session-v2",
+        agent: "general",
+        model: { id: "gpt-5.6-sol", limit: { context: 128_000 } },
+        system: ["You are a title generator for conversation sessions."],
+        messages: [],
+        tools: {},
+    }
+
+    await contextHook(event)
+
+    assert.equal(event.system.length, 1)
+    assert.equal(event.system[0], "You are a title generator for conversation sessions.")
+
+    await cleanup()
+})
+
+test("context hook inspects and prunes obsolete tool messages", async () => {
+    const fake = fakeContext()
+    const cleanup = await plugin.setup(fake.value)
+
+    const contextHook = fake.hooks.get("context")!
+    assert.ok(contextHook)
+
+    const userMsg = buildUserMessage("m1", "Please inspect the codebase.")
+    const toolMsg1 = buildToolMessage("m2", "read", "call-1", "A".repeat(5000))
+    const toolMsg2 = buildToolMessage("m3", "read", "call-2", "B".repeat(5000))
+    const assistantMsg = buildUserMessage("m4", "Found the relevant files.")
+
+    const messages = [userMsg, toolMsg1, toolMsg2, assistantMsg]
+
+    const event = {
+        sessionID: "session-v2",
+        agent: "general",
+        model: { id: "gpt-5.6-sol", limit: { context: 128_000 } },
+        system: [{ type: "text", text: "You are an assistant." }],
+        messages,
+        tools: {},
+    }
+
+    await contextHook(event)
+
+    assert.equal(event.messages.length, 4)
+    assert.ok(event.messages[0].info.id)
+
+    await cleanup()
+})
+
+test("event subscribe records compression lifecycle timing", async () => {
+    const fake = fakeContext()
+    const cleanup = await plugin.setup(fake.value)
+
+    assert.equal(fake.events.length > 0, true)
+    const subscriber = fake.events[0]
+
+    // Send pending event
+    await subscriber({
+        event: {
+            type: "message.part.updated",
+            properties: {
+                part: {
+                    type: "tool",
+                    tool: "compress",
+                    callID: "call-123",
+                    messageID: "msg-123",
+                    state: { status: "pending" },
+                },
+            },
+            time: Date.now(),
+        },
+    })
+
+    // Send completed event
+    await subscriber({
+        event: {
+            type: "message.part.updated",
+            properties: {
+                part: {
+                    type: "tool",
+                    tool: "compress",
+                    callID: "call-123",
+                    messageID: "msg-123",
+                    state: {
+                        status: "completed",
+                        time: { start: Date.now() - 500, end: Date.now() },
+                    },
+                },
+            },
+            time: Date.now(),
+        },
+    })
+
+    await cleanup()
+})
+
+test("context hook preserves native v2 messages with role and content", async () => {
+    const fake = fakeContext()
+    const cleanup = await plugin.setup(fake.value)
+
+    const contextHook = fake.hooks.get("context")!
+    assert.ok(contextHook)
+
+    const v2Messages = [{ role: "user", content: "Can you see this image? [Image 1]" }]
+
+    const event = {
+        sessionID: "session-v2-test",
+        agent: "general",
+        model: { id: "gemini-3.7-flash", limit: { context: 1_000_000 } },
+        system: [{ type: "text", text: "You are a helpful assistant." }],
+        messages: v2Messages,
+        tools: {},
+    }
+
+    await contextHook(event)
+
+    // Ensure messages array was NOT emptied
+    assert.equal(event.messages.length, 1)
+    assert.equal(event.messages[0].role, "user")
+    assert.ok(
+        typeof event.messages[0].content === "string" &&
+            event.messages[0].content.startsWith("Can you see this image? [Image 1]"),
+    )
+
+    await cleanup()
+})
+
+test("context hook avoids duplicate/overlapping system prompt injections on subsequent turns", async () => {
+    const fake = fakeContext()
+    const cleanup = await plugin.setup(fake.value)
+
+    const contextHook = fake.hooks.get("context")!
+    assert.ok(contextHook)
+
+    const event = {
+        sessionID: "session-v2-dedup",
+        agent: "general",
+        model: { id: "gpt-5.6-sol", limit: { context: 128_000 } },
+        system: [{ type: "text", text: "Base instructions for model." }],
+        messages: [{ role: "user", content: "Hello!" }],
+        tools: {},
+    }
+
+    // First call injects DCP system prompt
+    await contextHook(event)
+    const systemTextAfterTurn1 = (event.system[0] as any).text
+
+    // Second call should NOT duplicate or overlap system prompt
+    await contextHook(event)
+    const systemTextAfterTurn2 = (event.system[0] as any).text
+
+    assert.equal(systemTextAfterTurn1, systemTextAfterTurn2)
+
+    await cleanup()
+})
+
+test("context hook preserves assistant tool_calls and tool responses without dropping", async () => {
+    const fake = fakeContext()
+    const cleanup = await plugin.setup(fake.value)
+
+    const contextHook = fake.hooks.get("context")!
+    assert.ok(contextHook)
+
+    const toolCallId = "call_rTLVrYkpejmk6YF7geKMpRiM"
+    const v2Messages = [
+        { role: "user", content: "Check the files in directory" },
+        {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+                {
+                    id: toolCallId,
+                    type: "function",
+                    function: {
+                        name: "glob",
+                        arguments: JSON.stringify({ pattern: "*.ts" }),
+                    },
+                },
+            ],
+        },
+        {
+            role: "tool",
+            tool_call_id: toolCallId,
+            content: JSON.stringify(["index.ts", "package.json"]),
+        },
+    ]
+
+    const event = {
+        sessionID: "session-v2-tools",
+        agent: "general",
+        model: { id: "gpt-5.6-sol", limit: { context: 128_000 } },
+        system: [{ type: "text", text: "You are a helpful assistant." }],
+        messages: v2Messages,
+        tools: {},
+    }
+
+    await contextHook(event)
+
+    // Ensure all 3 messages are preserved
+    assert.equal(event.messages.length, 3)
+
+    // Ensure user message exists
+    assert.equal(event.messages[0].role, "user")
+
+    // Ensure assistant message retains tool_calls
+    assert.equal(event.messages[1].role, "assistant")
+    assert.ok(Array.isArray((event.messages[1] as any).tool_calls))
+    assert.equal((event.messages[1] as any).tool_calls[0].id, toolCallId)
+
+    // Ensure tool message is NOT dropped and retains tool_call_id
+    assert.equal(event.messages[2].role, "tool")
+    assert.equal((event.messages[2] as any).tool_call_id, toolCallId)
+    assert.ok((event.messages[2] as any).content.includes("index.ts"))
+
+    await cleanup()
+})

--- a/tests/v2-plugin.test.ts
+++ b/tests/v2-plugin.test.ts
@@ -438,3 +438,146 @@ test("context hook preserves assistant tool_calls and tool responses without dro
 
     await cleanup()
 })
+
+// Regression coverage for the fourth v2-port bug: every test above (and the
+// original 96/96 "passing" suite from the prior port) builds its fake ctx
+// with a full v1-shaped `ctx.client` (session.get/session.messages/tui.show
+// Toast all present) -- which is exactly why `const client = ctx?.client`
+// being permanently `undefined` under a real v2 host was never caught. The
+// real @opencode-ai/plugin Context has no `.client` field at all; it only
+// exposes domain-scoped capabilities (ctx.catalog, ctx.session with a
+// restricted method set, etc.). This fixture omits `client` entirely and
+// only wires up what v2 genuinely provides, then drives the exact sequence
+// that crashed live: a context-hook turn (which is the only place a v2
+// plugin ever sees message history) followed by a real compress-tool
+// execution with a real v2 Tool.Context (sessionID/agent/messageID/id/
+// progress only).
+function fakeV2OnlyContext() {
+    const hooks = new Map<string, (event: any) => Promise<void>>()
+    const tools = new Map<string, any>()
+    const commands = new Map<string, any>()
+    const models = [
+        {
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-6",
+            limit: { context: 200_000 },
+        },
+    ]
+
+    const createRegistration = (name: string) => ({ dispose: async () => {} })
+
+    const value = {
+        app: { name: "opencode", version: "2", channel: "test" },
+        directory: process.cwd(),
+        // Deliberately no `client` field -- this is the real v2 shape.
+        catalog: {
+            model: {
+                list: async () => ({ data: models }),
+            },
+        },
+        session: {
+            get: async ({ sessionID }: { sessionID: string }) => ({
+                id: sessionID,
+                parentID: undefined,
+            }),
+            hook: async (name: string, callback: (event: any) => Promise<void>) => {
+                hooks.set(name, callback)
+                return createRegistration(`session.hook:${name}`)
+            },
+        },
+        tool: {
+            transform: async (callback: (draft: any) => void) => {
+                callback({
+                    add: (toolDef: any) => {
+                        tools.set(toolDef.name, toolDef)
+                    },
+                })
+                return createRegistration("tool.transform")
+            },
+        },
+        command: {
+            transform: async (callback: (draft: any) => void) => {
+                callback({
+                    update: (id: string, updater: any) => {
+                        const entry: any = { name: id, template: "", description: "" }
+                        if (typeof updater === "function") updater(entry)
+                        commands.set(id, entry)
+                    },
+                })
+                return createRegistration("command.transform")
+            },
+        },
+        event: {
+            subscribe: async () => createRegistration("event.subscribe"),
+        },
+    }
+
+    return { value, hooks, tools, commands }
+}
+
+test("compress tool completes end-to-end with no ctx.client at all (real v2 shape)", async () => {
+    const fake = fakeV2OnlyContext()
+    const cleanup = await plugin.setup(fake.value)
+
+    const sessionID = "ses_v2_no_client"
+    const contextHook = fake.hooks.get("context")!
+    assert.ok(contextHook)
+
+    // A real context-hook turn is the only way v2 ever exposes message
+    // history to this plugin -- this is what populates the message cache
+    // that the compress tool falls back to instead of a nonexistent
+    // client.session.messages() call.
+    const event = {
+        sessionID,
+        agent: "general",
+        model: { id: "claude-sonnet-4-6", providerID: "anthropic" },
+        system: [{ type: "text", text: "You are a helpful assistant." }],
+        messages: [
+            { role: "user", content: "Investigate the auth module." },
+            { role: "assistant", content: "Found the relevant code path." },
+            { role: "user", content: "Please summarize what we found so far." },
+        ],
+        tools: {},
+    }
+
+    await contextHook(event)
+
+    // Model context limit must resolve via ctx.catalog.model.list(), not a
+    // nonexistent client.model.list().
+    assert.equal(fake.hooks.size > 0, true)
+
+    const compressTool = fake.tools.get("compress")
+    assert.ok(compressTool)
+
+    // Real v2 Tool.Context: no ask, no metadata, no client.
+    const toolCtx = {
+        sessionID,
+        agent: "general",
+        messageID: "msg-compress-call",
+        id: "call-compress-v2-only",
+        progress: async () => {},
+    }
+
+    const messageIds = Array.from((event.messages as any[]).keys()).map(
+        (i) => `m${(i + 1).toString().padStart(4, "0")}`,
+    )
+
+    const result = await compressTool.execute(
+        {
+            topic: "v2 client-less compress",
+            content: [
+                {
+                    startId: messageIds[0],
+                    endId: messageIds[1],
+                    summary: "Investigated the auth module and found the relevant code path.",
+                },
+            ],
+        },
+        toolCtx,
+    )
+
+    assert.equal(typeof result?.content?.[0]?.text, "string")
+    assert.ok(result.content[0].text.includes("Compressed"))
+
+    await cleanup()
+})

--- a/tests/v2-plugin.test.ts
+++ b/tests/v2-plugin.test.ts
@@ -167,6 +167,15 @@ test("setup registers context hook, compress tool, and dcp-compress command", as
     assert.equal(dcpCommand.name, "dcp-compress")
     assert.ok(dcpCommand.description.includes("dcp-compress"))
 
+    // v2 has no command-execution hook: a command's `template` IS the whole
+    // prompt sent to the model. An empty template (what a prior v2 port left
+    // in place) means running /dcp-compress submits nothing useful. Lock
+    // that it now carries real compress-trigger instructions plus the
+    // $ARGUMENTS placeholder so optional focus text still gets threaded in.
+    assert.ok(typeof dcpCommand.template === "string" && dcpCommand.template.length > 0)
+    assert.ok(dcpCommand.template.includes("You must now use the compress tool"))
+    assert.ok(dcpCommand.template.includes("$ARGUMENTS"))
+
     await cleanup()
     assert.ok(fake.disposed.includes("session.hook:context"))
     assert.ok(fake.disposed.includes("tool.transform"))


### PR DESCRIPTION
Fix five v2-port bugs: nudges never fire, /dcp-compress crashes on every path

## Summary

`opencode-dcp`'s v2 `Plugin.define`/`setup()` path (already present in the
published package) has five distinct bugs that together mean the plugin
never automatically compresses under a real v2 host, and `/dcp-compress`
(and the `compress` tool itself, however triggered) fails on every single
invocation. All five were reproduced live against a real v2 host, not just
under this PR's own test mocks — see the individual commits for exact repro
traces.

I found these while getting DCP working on a v2-only OpenCode install. Happy
to adjust scope/approach if you'd rather split this into smaller PRs, or if
some of this overlaps with in-flight work on your end — this whole area
(the v2 `setup()` path) looks like it's mid-port already, so apologies in
advance if any of this steps on toes.

## Bugs fixed (one commit each)

**1. `getCurrentTokenUsage()` always returns 0 for v2 native messages → auto-compress nudges never fire**

`AssistantMessage.tokens` is a required field on a real `SessionMessage`,
but v2's `session.hook("context")` event passes native `@opencode-ai/ai`
`Message` objects with no `tokens` field at all, and the synthetic `.info`
this plugin fabricates for them never sets one either. The token-usage scan
always ran off the end and returned 0, so `isContextOverLimits()` never
tripped regardless of real context size. Falls back to the plugin's own
local-tokenizer estimate (`estimateCurrentTokenUsage`, built from the
existing `countAllMessageTokens`) whenever no message actually carries a
real reported `tokens` object.

Related, same commit: `event.model` on the v2 context hook is a bare
`Model.Ref` (id/providerID/variant), never `Model.Info` with
`.limit.context` — added `resolveModelContextLimit()`, resolving/caching the
context window via the model catalog when the event doesn't carry it, so
percentage-based `maxContextLimit`/`minContextLimit` configs still work
under v2.

**2. `/dcp-compress`'s command template was empty under v2 → the command submitted nothing**

v2's `CommandDomain` only exposes `transform`/`reload` — there's no
per-invocation execution hook like v1's `command.execute.before` to fill in
a command's prompt at runtime. A command's `template` _is_ the entire
prompt sent to the model. The v2 registration left `template: ""`, relying
on the (now nonexistent under v2) execute hook to replace it — so running
`/dcp-compress` submitted an empty message and errored (provider 400 /
prefill error). Fixed by giving the command its real static template
(exported `COMPRESS_TRIGGER_PROMPT` + `$ARGUMENTS`) at registration time.

**3. `prepareSession()`'s `toolCtx.ask()`/`.metadata()` calls don't exist on v2's `Tool.Context` → every compress execution crashed**

Confirmed against both `@opencode-ai/plugin`'s `promise/tool.d.ts` and
`effect/tool.d.ts`: the real v2 `Tool.Context` is exactly
`{ sessionID, agent, messageID, id, progress }`. `prepareSession()` called
`toolCtx.ask(...)` (v1's interactive permission prompt) and
`toolCtx.metadata(...)` (v1's UI title-setter) unconditionally as the first
thing it did, in both compress modes — `toolCtx.ask is not a function` on
line one of every execution. Guarded both behind a `typeof` check.

Known, accepted simplification: v1's `ask()` enforced
`compress.permission === "ask"` with an interactive prompt at execute time;
v2 has no equivalent mid-execution permission-request hook, so v2 currently
proceeds without prompting. Irrelevant for the default `"allow"`; only
affects users who've explicitly set `"ask"`.

**4. `ctx.client` does not exist under v2 at all**

The biggest one. `const client = ctx?.client` in `index.ts`'s v2 `setup()`
has been `undefined` for the life of every v2 process — confirmed against
the installed `@opencode-ai/plugin` `Context` type, which has no `.client`
field (`app/options/agent/aisdk/catalog/command/event/integration/plugin/
reference/session/shell/skill/tool/websearch` only). This affected ~12 call
sites across 6 files, all still using v1 method names and v1 REST-shaped
inputs (`client.session.messages({path:{id}})`,
`client.session.get({path:{id}})`, `client.model.list()`,
`client.tui.showToast(...)`, `client.session.prompt({path,body})`) —
including this PR's own commit 1 fix, which silently no-op'd instead of
crashing because it was written to swallow client errors defensively.

Root architecture gap, confirmed against the real v2 types rather than
assumed: v2's plugin `Context` deliberately does not expose session message
history to plugins at all. `SessionDomain` only picks `create | get |
prompt | generate | command | synthetic | interrupt | hook` off the full
`SessionApi` — `.messages`/`.export` are excluded, and there's no separate
`ctx.message` domain either, even though `MessageApi.list({sessionID})`
exists on the full client. The only place a v2 plugin ever sees message
content is the live `messages` array handed to it inside
`ctx.session.hook("context", ...)`.

Fix:

- `lib/v2-client-shim.ts` (new): translates the v1-shaped calls the rest of
  the codebase already makes into real v2 `ctx` calls where one exists
  (`model.list` → `ctx.catalog.model.list()`, `session.get` →
  `ctx.session.get({sessionID})` with input-shape translation), and
  degrades predictably where v2 has none at all: `session.messages` falls
  back to a cache (next item); `session.prompt` throws a labelled,
  already-caught error, since v2's real `session.prompt` input has no
  `ignored`/`noReply` equivalent — a real call would send a visible message
  and solicit an actual, unwanted model turn.
- `lib/state/message-cache.ts` (new): a `sessionID → messages` cache,
  populated every context-hook turn by `createChatMessageTransformHandler`
  (the only place v2 ever hands this plugin full message history, for the
  main session and any subagent sub-session that also gets its own
  context-hook turn). `fetchSessionMessages`, `fetchSubAgentMessages`,
  `isSubAgentSession`, and `resolveModelContextLimit` needed **zero
  call-site changes** — they still call the same v1-shaped methods, now
  backed by the shim.
- `index.ts`: `const client = ctx?.client ?? buildV2ClientCompat(ctx)`;
  `configureClientAuth` (v1/secure-mode only) now only runs against a real
  client, never the synthetic shim.
- `lib/ui/notification.ts`, `lib/update.ts`: guarded the remaining
  `client.tui.showToast`/`ctx.client.tui.showToast` call sites (v2 has no
  toast/TUI domain for plugins at all) to log-and-skip instead of crashing.
  One, in `update.ts`, was previously unguarded inside a bare `setTimeout`
  with no surrounding try/catch at all.

**5. `getCurrentParams()` assumes every message's `.info.model` exists**

True for a real v1 `SessionMessage`, never set on the synthetic `.info`
this plugin fabricates for v2 native AI SDK messages
(`{id, sessionID, role, time}` only). Found only because bug #4's fix let
`finalizeSession` run live for the first time — crashed _after_ the
compression had already been applied to state, a partial/inconsistent
failure. Optional-chained the three field reads.

## Why none of this was caught before

Every existing v2-plugin test mocks `event.model` with `.limit.context`
already populated, every message with a real `tokens` object already
attached, `toolCtx` with v1's `ask()`/`metadata()` present, and — this is
the big one — `ctx.client` as a full, working, v1-shaped client. None of
those five assumptions match what a real v2 host actually provides. This PR
adds regression tests for each bug modeling the real shape instead: no
`event.model.limit`, no per-message `tokens`, a real `Tool.Context`
(`sessionID/agent/messageID/id/progress` only), and — the first test in the
whole suite to do this — **no `ctx.client` field at all**, only
`ctx.catalog.model.list()` and `ctx.session.get()`.

## Validation

- `npm run typecheck` — passes
- `npm test` — 105/105 passing (up from the prior suite's 96)
- `npm run build` — passes
- Manually verified live against a real v2 OpenCode host: `/dcp-compress`
  now completes a real compression instead of erroring, in a fresh session
  after the fix was loaded.

Happy to split this up, rename things, or change the shim's shape if you'd
prefer a different approach to the v2 client-capability gap (or if you're
already planning to file the message-history gap upstream with OpenCode
itself, in which case the cache workaround here could be dropped once
that's exposed).
